### PR TITLE
fix plaintext information leak

### DIFF
--- a/transcrypt
+++ b/transcrypt
@@ -209,7 +209,7 @@ save_configuration() {
 	# hash for the file's unique salt.
 	local cipher_cmd='$(git config --get --local transcrypt.cipher)'
 	local password_cmd='$(git config --get --local transcrypt.password)'
-	local salt_cmd='$(openssl dgst -sha256 %f | tail -c 16)'
+	local salt_cmd="\$(openssl dgst -hmac \"%f:$password_cmd\" -sha256 %f | tail -c 16)"
 
 	# write the filter settings
 	git config filter.crypt.clean "openssl enc -$cipher_cmd -pass \"pass:$password_cmd\" -e -a -S $salt_cmd 2> /dev/null"


### PR DESCRIPTION
This changes the salt for a file to be the HMAC of its contents keyed
with filename:password instead of the plain hash of its contents. Pre-
change an attacker may make guesses at the files contents and confirm
them with high probability by checking to see whether the salt matches.
This would be a concern in the case of a config file where almost
everything is known, for example everything excpet for a password is
known. This change also prevents an attacker from seeing that the
contents of two encrypted files are the same.

There may still be other security issues.

This commit doesn't change the version number or try to maintain
compatibility with older repos.
