### PR TITLE
Create --force command line option to ignore cleanliness of repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,10 @@ directory.
            remove the locally cached encryption credentials
            and re-encrypt any files that had been previously decrypted
 
+      -F, --force
+           ignore whether the git directory is clean, proceed with the
+           possibility that uncommitted changes are overwritten
+
       -u, --uninstall
            remove all transcrypt configuration from the repository
            and leave files in the current working copy decrypted

--- a/contrib/bash/transcrypt
+++ b/contrib/bash/transcrypt
@@ -21,8 +21,8 @@ _transcrypt() {
 	COMPREPLY=()
 	cur="${COMP_WORDS[COMP_CWORD]}"
 	prev="${COMP_WORDS[COMP_CWORD-1]}"
-	opts="-c -p -y -d -r -f -u -l -s -v -h \
-	      --cipher --password --yes --display --rekey --flush-credentials --uninstall --list --show-raw --version --help"
+	opts="-c -p -y -d -r -f -F -u -l -s -v -h \
+	      --cipher --password --yes --display --rekey --flush-credentials --force --uninstall --list --show-raw --version --help"
 
 	case "${prev}" in
 		-c | --cipher)

--- a/man/transcrypt.1.ronn
+++ b/man/transcrypt.1.ronn
@@ -38,6 +38,10 @@ The transcrypt source code and full documentation may be downloaded from
     remove the locally cached encryption credentials
     and re-encrypt any files that had been previously decrypted
 
+  * `-F`, `--force`:
+    ignore whether the git directory is clean, proceed with the
+    possibility that uncommitted changes are overwritten
+
   * `-u`, `--uninstall`:
     remove all transcrypt configuration from the repository
     and leave files in the current working copy decrypted

--- a/transcrypt
+++ b/transcrypt
@@ -456,6 +456,10 @@ help() {
 	            remove the locally cached encryption credentials and  re-encrypt
 	            any files that had been previously decrypted
 
+	     -F, --force
+	            ignore whether the git directory is clean, proceed with the
+	            possibility that uncommitted changes are overwritten
+
 	     -u, --uninstall
 	            remove  all  transcrypt  configuration  from  the repository and
 	            leave files in the current working copy decrypted
@@ -565,6 +569,9 @@ do
 		-f | --flush-credentials)
 			flush_creds='true'
 			requires_existing_config='true'
+			;;
+		-F | --force)
+			unset requires_clean_repo
 			;;
 		-u | --uninstall)
 			uninstall='true'


### PR DESCRIPTION
This came up when I was using transcrypt in a production setting where the repo necessarily was dirty due to deploy artifacts. 
