### PR TITLE
Fix issue in recent versions of git where filters won't run until you re...

### DIFF
--- a/transcrypt
+++ b/transcrypt
@@ -294,6 +294,7 @@ force_checkout() {
 		# this would normally delete uncommitted changes in the working directory,
 		# but we already made sure the repo was clean during the safety checks
 		cd "$REPO"
+		git ls-crypt | xargs rm
 		git checkout --force HEAD -- $(git ls-crypt) > /dev/null
 	fi
 }


### PR DESCRIPTION
...move/recheckout the files.

http://git-scm.com/book/en/v2/Customizing-Git-Git-Attributes#Keyword-Expansion
See "The next time you check out this file..."

The issue we saw was that after setting up transcrypt was that none of the encrypted files were getting decrypted. Many hours of tracing later... transcrypt worked fine on Git 1.9 (that comes with OSX Yosemite) and not with brew's git (2.3.0 or 2.3.3 or HEAD).

It looks like there was a change to the filtering behavior, probably a perf patch, but I can't track down what revision in git it was in. It would be trivial with git bisect and a test, but don't have time at the moment.

Thanks!