### PR TITLE
Add basic GPG import/export features

### DIFF
--- a/transcrypt
+++ b/transcrypt
@@ -403,6 +403,7 @@ export_gpg() {
 	local encrypted_config 
 	encrypted_config=$(echo -e "password='$current_password'\ncipher='$current_cipher'" | gpg --batch -r $gpg_recipient --always-trust --yes -aqe -)
 	echo "$encrypted_config" > "$REPO/.git/crypt/$gpg_recipient.asc"
+	printf "Successfully exported cipher and password to:\n\t\t'$REPO/.git/crypt/$gpg_recipient.asc'\n"
 }
 
 # import password and cipher from a GPG encrypted file
@@ -424,6 +425,7 @@ import_gpg() {
 	done
 
 	eval "$settings"
+	printf "Successfully imported cipher and password from '$gpg_config_file'\n"
 }
 
 # list all of the currently encrypted files in the repository

--- a/transcrypt
+++ b/transcrypt
@@ -403,7 +403,7 @@ export_gpg() {
 	local encrypted_config 
 	encrypted_config=$(echo -e "password='$current_password'\ncipher='$current_cipher'" | gpg --batch -r $gpg_recipient --always-trust --yes -aqe -)
 	echo "$encrypted_config" > "$REPO/.git/crypt/$gpg_recipient.asc"
-	printf "Successfully exported cipher and password to:\n\t\t'$REPO/.git/crypt/$gpg_recipient.asc'\n"
+	printf "Successfully exported cipher and password to:\n\n\t'$REPO/.git/crypt/$gpg_recipient.asc'\n"
 }
 
 # import password and cipher from a GPG encrypted file

--- a/transcrypt
+++ b/transcrypt
@@ -412,14 +412,14 @@ import_gpg() {
 	[[ ! $gpg_config_file ]] && die 1 "no file passed and no '.asc' file found in '$REPO/.git/crypt/'"
 
 	local settings
-	local saftey_counter = 0
+	local saftey_counter
 	# Fix for MacGPG / GPG having intermittent decryption failures stating 'No secret key' when there is
 	while [[ ! $settings ]]
 	do
 		settings=$(gpg --batch -qd "$gpg_config_file")
 
 		saftey_counter=$((saftey_counter+1))
-		if [[ $saftey_counter == 5 ]]; then
+		if [[ $saftey_counter == 3 ]]; then
 			die 1 "unable to decrypt '$gpg_config_file'"
 		fi
 	done

--- a/transcrypt
+++ b/transcrypt
@@ -387,6 +387,24 @@ uninstall_transcrypt() {
 	fi
 }
 
+# export password and cipher to a GPG encrypted file
+export_gpg() {
+	local current_cipher=$(git config --get --local transcrypt.cipher)
+	local current_password=$(git config --get --local transcrypt.password)
+
+	[[ ! -d "$REPO/.git/crypt" ]] && mkdir "$REPO/.git/crypt"
+
+	local key_exists
+	key_exists=$(gpg --with-colons --list-keys | grep $gpg_recipient)
+	if [[ ! $key_exists ]]; then
+		die 1 'GPG recipient key "$gpg_recipient" does not exist'
+	fi
+
+	local encrypted_config 
+	encrypted_config=$(echo -e "password='$current_password'\ncipher='$current_cipher'" | gpg --batch -r $gpg_recipient --always-trust --yes -aqe -)
+	echo "$encrypted_config" > "$REPO/.git/crypt/$gpg_recipient.asc"
+}
+
 # list all of the currently encrypted files in the repository
 list_files() {
 	cd "$REPO"
@@ -482,6 +500,11 @@ help() {
 	            show  the  raw file as stored in the git commit object; use this
 	            to check if files are encrypted as expected
 
+	     -e, --export-gpg=KEYID
+	            export password and cipher to file encrypted with recipient set
+	            to KEYID. Exported file can be found in:
+	                      '<repo>/.git/crypt/<KEYID>.asc'
+
 	     -v, --version
 	            print the version information
 
@@ -541,6 +564,8 @@ rekey=''
 flush_creds=''
 uninstall=''
 show_file=''
+gpg_recipient=''
+export_to_gpg='false'
 
 # used to bypass certain safety checks
 requires_existing_config=''
@@ -602,6 +627,19 @@ do
 			show_raw_file
 			exit 0
 			;;
+		-e | --export-gpg)
+			export_to_gpg='true'
+			gpg_recipient=$2
+			requires_existing_config='true'
+			unset requires_clean_repo
+			shift
+			;;
+		--export-gpg=*)
+			export_to_gpg='true'
+			gpg_recipient=${1#*=}
+			requires_existing_config='true'
+			unset requires_clean_repo
+			;;
 		-v | --version)
 			printf "transcrypt $VERSION\n"
 			exit 0
@@ -645,6 +683,9 @@ elif [[ $flush_creds ]]; then
 	exit 0
 elif [[ $cipher ]]; then
 	validate_cipher
+elif [[ $export_to_gpg ]]; then
+	export_gpg
+	exit 0
 fi
 
 # perform function calls to configure transcrypt

--- a/transcrypt
+++ b/transcrypt
@@ -592,8 +592,6 @@ uninstall=''
 show_file=''
 gpg_recipient=''
 gpg_config_file=''
-export_to_gpg='false'
-import_from_gpg='false'
 
 # used to bypass certain safety checks
 requires_existing_config=''

--- a/transcrypt
+++ b/transcrypt
@@ -405,6 +405,27 @@ export_gpg() {
 	echo "$encrypted_config" > "$REPO/.git/crypt/$gpg_recipient.asc"
 }
 
+# import password and cipher from a GPG encrypted file
+import_gpg() {
+	[[ ! $gpg_config_file ]] && gpg_config_file=$(ls -1 $REPO/.git/crypt/*.asc | sort | head -n1)
+	[[ ! $gpg_config_file ]] && die 1 "no file passed and no '.asc' file found in '$REPO/.git/crypt/'"
+
+	local settings
+	local saftey_counter = 0
+	# Fix for MacGPG / GPG having intermittent decryption failures stating 'No secret key' when there is
+	while [[ ! $settings ]]
+	do
+		settings=$(gpg --batch -qd "$gpg_config_file")
+
+		saftey_counter=$((saftey_counter+1))
+		if [[ $saftey_counter == 5 ]]; then
+			die 1 "unable to decrypt '$gpg_config_file'"
+		fi
+	done
+
+	eval "$settings"
+}
+
 # list all of the currently encrypted files in the repository
 list_files() {
 	cd "$REPO"
@@ -505,6 +526,11 @@ help() {
 	            to KEYID. Exported file can be found in:
 	                      '<repo>/.git/crypt/<KEYID>.asc'
 
+	     -i, --import-gpg=FILE
+	            import password and cipher from gpg encrypted file. Defaults to
+	            the first .asc file in: '<repo>/.git/crypt/'. Runs a force
+	            checkout after import.
+
 	     -v, --version
 	            print the version information
 
@@ -565,7 +591,9 @@ flush_creds=''
 uninstall=''
 show_file=''
 gpg_recipient=''
+gpg_config_file=''
 export_to_gpg='false'
+import_from_gpg='false'
 
 # used to bypass certain safety checks
 requires_existing_config=''
@@ -640,6 +668,15 @@ do
 			requires_existing_config='true'
 			unset requires_clean_repo
 			;;
+		-i | --import-gpg)
+			import_from_gpg='true'
+			gpg_config_file=$2
+			shift
+			;;
+		--import-gpg=*)
+			import_from_gpg='true'
+			gpg_config_file=${1#*=}
+			;;
 		-v | --version)
 			printf "transcrypt $VERSION\n"
 			exit 0
@@ -686,6 +723,8 @@ elif [[ $cipher ]]; then
 elif [[ $export_to_gpg ]]; then
 	export_gpg
 	exit 0
+elif [[ $import_from_gpg ]]; then
+	import_gpg
 fi
 
 # perform function calls to configure transcrypt

--- a/transcrypt
+++ b/transcrypt
@@ -525,13 +525,11 @@ help() {
 
 	     -e, --export-gpg=KEYID
 	            export password and cipher to file encrypted with recipient set
-	            to KEYID. Exported file can be found in:
-	                      '<repo>/.git/crypt/<KEYID>.asc'
+	            to KEYID.
 
 	     -i, --import-gpg=FILE
 	            import password and cipher from gpg encrypted file. Defaults to
-	            the first .asc file in: '<repo>/.git/crypt/'. Runs a force
-	            checkout after import.
+	            the first .asc file in: '<repo>/.git/crypt/'.
 
 	     -v, --version
 	            print the version information

--- a/transcrypt
+++ b/transcrypt
@@ -397,7 +397,7 @@ export_gpg() {
 	local key_exists
 	key_exists=$(gpg --with-colons --list-keys | grep $gpg_recipient)
 	if [[ ! $key_exists ]]; then
-		die 1 'GPG recipient key "$gpg_recipient" does not exist'
+		die 1 "GPG recipient key '$gpg_recipient' does not exist"
 	fi
 
 	local encrypted_config 


### PR DESCRIPTION
I've added 2 additional features:

1. Export current password and cipher to file encrypted with a recipient GPG key.
2. Import password and cipher from a GPG encrypted file.

Export to GPG allows you to export for someone else or to backup a local copy of the pass/cipher for yourself (using your own pub key id), ready for a flush or to setup a new user.

``` bash
$ transcrypt -e <KEYID>
```

Import will detect (crudely) a previously exported pass/cipher OR you can point it at a file on your system. It will then re-run the save_config once the pass/cipher have been imported.

``` bash
$ transcrypt -i <FILE>
```

You can setup new users by using their pub key ID for an export and sending the exported file to them. When they run the import their whole repo will be setup as if they init'd, just with the pass and cipher pre-set.

I haven't tested this with all the other options, nor have I added additional documentation yet, wanted to see what the general feel was for it?