### PR TITLE
Do not alter output with repeated filter commands

### DIFF
--- a/transcrypt
+++ b/transcrypt
@@ -211,10 +211,13 @@ save_helper_scripts() {
 	cat <<-'EOF' > "${REPO}/.git/crypt/clean"
 		#!/usr/bin/env bash
 		filename=$1
-		cipher=$(git config --get --local transcrypt.cipher)
-		password=$(git config --get --local transcrypt.password)
-		salt=$(openssl dgst -hmac "${filename}:${password}" -sha256 "$filename" | tail -c 16)
-		ENC_PASS=$password openssl enc -$cipher -pass env:ENC_PASS -e -a -S "$salt"
+		# ignore empty files
+		if [[ -s $filename ]]; then
+		  cipher=$(git config --get --local transcrypt.cipher)
+		  password=$(git config --get --local transcrypt.password)
+		  salt=$(openssl dgst -hmac "${filename}:${password}" -sha256 "$filename" | tail -c 16)
+		  ENC_PASS=$password openssl enc -$cipher -pass env:ENC_PASS -e -a -S "$salt"
+		fi
 	EOF
 
 	cat <<-'EOF' > "${REPO}/.git/crypt/smudge"
@@ -229,9 +232,12 @@ save_helper_scripts() {
 	cat <<-'EOF' > "${REPO}/.git/crypt/textconv"
 		#!/usr/bin/env bash
 		filename=$1
-		cipher=$(git config --get --local transcrypt.cipher)
-		password=$(git config --get --local transcrypt.password)
-		ENC_PASS=$password openssl enc -$cipher -pass env:ENC_PASS -d -a -in "$filename" 2> /dev/null || cat "$filename"
+		# ignore empty files
+		if [[ -s $filename ]]; then
+		  cipher=$(git config --get --local transcrypt.cipher)
+		  password=$(git config --get --local transcrypt.password)
+		  ENC_PASS=$password openssl enc -$cipher -pass env:ENC_PASS -d -a -in "$filename" 2> /dev/null || cat "$filename"
+		fi
 	EOF
 
 	# make scripts executable

--- a/transcrypt
+++ b/transcrypt
@@ -270,6 +270,8 @@ save_configuration() {
 	git config filter.crypt.smudge '"$(git rev-parse --show-toplevel)"/.git/crypt/smudge'
 	git config filter.crypt.required 'true'
 	git config diff.crypt.textconv '"$(git rev-parse --show-toplevel)"/.git/crypt/textconv'
+	git config diff.crypt.cachetextconv 'true'
+	git config diff.crypt.binary 'true'
 	git config merge.renormalize 'true'
 
 	# add a git alias for listing encrypted files

--- a/transcrypt
+++ b/transcrypt
@@ -213,10 +213,20 @@ save_helper_scripts() {
 		filename=$1
 		# ignore empty files
 		if [[ -s $filename ]]; then
-		  cipher=$(git config --get --local transcrypt.cipher)
-		  password=$(git config --get --local transcrypt.password)
-		  salt=$(openssl dgst -hmac "${filename}:${password}" -sha256 "$filename" | tail -c 16)
-		  ENC_PASS=$password openssl enc -$cipher -pass env:ENC_PASS -e -a -S "$salt"
+		  # cache STDIN to test if it's already encrypted
+		  tempfile=$(mktemp /tmp/transcrypt.XXXXXX)
+		  trap 'rm -f "$tempfile"' EXIT
+		  tee "$tempfile" &> /dev/null
+		  # the first bytes of an encrypted file are always "Salted" in Base64
+		  read -n 8 firstbytes < "$tempfile"
+		  if [[ $firstbytes == "U2FsdGVk" ]]; then
+		    cat "$tempfile"
+		  else
+		    cipher=$(git config --get --local transcrypt.cipher)
+		    password=$(git config --get --local transcrypt.password)
+		    salt=$(openssl dgst -hmac "${filename}:${password}" -sha256 "$filename" | tail -c 16)
+		    ENC_PASS=$password openssl enc -$cipher -pass env:ENC_PASS -e -a -S "$salt" -in "$tempfile"
+		  fi
 		fi
 	EOF
 

--- a/transcrypt
+++ b/transcrypt
@@ -219,9 +219,11 @@ save_helper_scripts() {
 
 	cat <<-'EOF' > "${REPO}/.git/crypt/smudge"
 		#!/usr/bin/env bash
+		tempfile=$(mktemp /tmp/transcrypt.XXXXXX)
+		trap 'rm -f "$tempfile"' EXIT
 		cipher=$(git config --get --local transcrypt.cipher)
 		password=$(git config --get --local transcrypt.password)
-		ENC_PASS=$password openssl enc -$cipher -pass env:ENC_PASS -d -a 2> /dev/null
+		tee "$tempfile" | ENC_PASS=$password openssl enc -$cipher -pass env:ENC_PASS -d -a 2> /dev/null || cat "$tempfile"
 	EOF
 
 	cat <<-'EOF' > "${REPO}/.git/crypt/textconv"

--- a/transcrypt
+++ b/transcrypt
@@ -67,7 +67,7 @@ run_safety_checks() {
 	fi
 
 	# check for dependencies
-	for cmd in {grep,openssl,sed}; do
+	for cmd in {grep,mktemp,openssl,sed,tee}; do
 		command -v $cmd > /dev/null || die 'required command "%s" was not found' "$cmd"
 	done
 


### PR DESCRIPTION
Per the `gitattributes` man page, the filter command behavior should be a bit more strict:

> For best results, clean should not alter its output further if it is run
> twice ("clean->clean" should be equivalent to "clean"), and multiple smudge
> commands should not alter clean's output ("smudge->smudge->clean" should be
> equivalent to "clean"). See the section on merging below.

This does add some complexity surrounding the capturing of STDIN, but I think the tempfiles are okay. I'm going to keep testing with this branch for a bit before I merge to see if there are any unintended consequences.

This also allows us to handle the empty files more gracefully (by skipping them explicitly), so it will resolve #27.