### PR TITLE
Generalize handling of repository path references

### DIFF
--- a/transcrypt
+++ b/transcrypt
@@ -194,6 +194,7 @@ confirm_configuration() {
 	local answer
 
 	printf '\nThe following configuration will be saved:\n\n'
+	[[ $REPO ]] && printf '  GIT_WORK_TREE:  %s\n' "$REPO"
 	printf '  GIT_DIR:        %s\n' "$GIT_DIR"
 	printf '  GIT_ATTRIBUTES: %s\n\n' "$GIT_ATTRIBUTES"
 	printf '  CIPHER:   %s\n' "$cipher"
@@ -215,6 +216,7 @@ confirm_rekey() {
 	local answer
 
 	printf '\nThe following configuration will be saved:\n\n'
+	[[ $REPO ]] && printf '  GIT_WORK_TREE:  %s\n' "$REPO"
 	printf '  GIT_DIR:        %s\n' "$GIT_DIR"
 	printf '  GIT_ATTRIBUTES: %s\n\n' "$GIT_ATTRIBUTES"
 	printf '  CIPHER:   %s\n' "$cipher"
@@ -335,6 +337,7 @@ display_configuration() {
 
 	printf 'The current repository was configured using transcrypt version %s\n' "$CONFIGURED"
 	printf 'and has the following configuration:\n\n'
+	[[ $REPO ]] && printf '  GIT_WORK_TREE:  %s\n' "$REPO"
 	printf '  GIT_DIR:        %s\n' "$GIT_DIR"
 	printf '  GIT_ATTRIBUTES: %s\n\n' "$GIT_ATTRIBUTES"
 	printf '  CIPHER:   %s\n' "$current_cipher"

--- a/transcrypt
+++ b/transcrypt
@@ -319,10 +319,18 @@ save_configuration() {
 	git config transcrypt.password "$password"
 
 	# write the filter settings
-	git config filter.crypt.clean '"$(git rev-parse --git-dir)"/crypt/clean %f'
-	git config filter.crypt.smudge '"$(git rev-parse --git-dir)"/crypt/smudge'
+	if [[ -d $(git rev-parse --git-common-dir) ]]; then
+		# this allows us to support multiple working trees via git-worktree
+		# ...but the --git-common-dir flag was only added in November 2014
+		git config filter.crypt.clean '"$(git rev-parse --git-common-dir)"/crypt/clean %f'
+		git config filter.crypt.smudge '"$(git rev-parse --git-common-dir)"/crypt/smudge'
+		git config diff.crypt.textconv '"$(git rev-parse --git-common-dir)"/crypt/textconv'
+	else
+		git config filter.crypt.clean '"$(git rev-parse --git-dir)"/crypt/clean %f'
+		git config filter.crypt.smudge '"$(git rev-parse --git-dir)"/crypt/smudge'
+		git config diff.crypt.textconv '"$(git rev-parse --git-dir)"/crypt/textconv'
+	fi
 	git config filter.crypt.required 'true'
-	git config diff.crypt.textconv '"$(git rev-parse --git-dir)"/crypt/textconv'
 	git config diff.crypt.cachetextconv 'true'
 	git config diff.crypt.binary 'true'
 	git config merge.renormalize 'true'

--- a/transcrypt
+++ b/transcrypt
@@ -66,14 +66,10 @@ RELATIVE_GIT_DIR=$(git rev-parse --git-dir 2> /dev/null)
 readonly GIT_DIR=$(realpath "$RELATIVE_GIT_DIR")
 
 # the current git repository's gitattributes file
-if [[ $IS_VCSH == 'true' ]]; then
-	VCSH_ATTRIBUTES=$(git config --get --local core.attributesfile)
-	if [[ $VCSH_ATTRIBUTES ]]; then
-		readonly GIT_ATTRIBUTES=$VCSH_ATTRIBUTES
-	else
-		readonly GIT_ATTRIBUTES="${GIT_DIR}/info/attributes"
-	fi
-elif [[ $IS_BARE == 'true' ]]; then
+readonly CORE_ATTRIBUTES=$(git config --get --local --path core.attributesFile)
+if [[ $CORE_ATTRIBUTES ]]; then
+	readonly GIT_ATTRIBUTES=$CORE_ATTRIBUTES
+elif [[ $IS_BARE == 'true' ]] || [[ $IS_VCSH == 'true' ]]; then
 	readonly GIT_ATTRIBUTES="${GIT_DIR}/info/attributes"
 else
 	readonly GIT_ATTRIBUTES="${REPO}/.gitattributes"

--- a/transcrypt
+++ b/transcrypt
@@ -20,14 +20,17 @@ readonly VERSION='0.9.7'
 # the default cipher to utilize
 readonly DEFAULT_CIPHER='aes-256-cbc'
 
-# the current git repository's top-level directory
-readonly REPO=$(git rev-parse --show-toplevel 2> /dev/null)
-
 # whether or not transcrypt is already configured
 readonly CONFIGURED=$(git config --get --local transcrypt.version 2> /dev/null)
 
+# the current git repository's .git directory
+readonly GIT_DIR=$(git rev-parse --git-dir 2> /dev/null)
+
 # whether or not a HEAD revision exists
 readonly HEAD_EXISTS=$(git rev-parse --verify --quiet HEAD 2> /dev/null)
+
+# the current git repository's top-level directory
+readonly REPO=$(git rev-parse --show-toplevel 2> /dev/null)
 
 # regular expression used to test user input
 readonly YES_REGEX='^[Yy]$'
@@ -57,7 +60,7 @@ die() {
 # verify that all requirements have been met
 run_safety_checks() {
 	# validate that we're in a git repository
-	[[ $REPO ]] || die 'you are not currently in a git repository; did you forget to run "git init"?'
+	[[ $GIT_DIR ]] || die 'you are not currently in a git repository; did you forget to run "git init"?'
 
 	# exit if transcrypt is not in the required state
 	if [[ $requires_existing_config ]] && [[ ! $CONFIGURED ]]; then
@@ -147,7 +150,7 @@ confirm_configuration() {
 	local answer
 
 	printf '\nThe following configuration will be saved:\n\n'
-	printf '  REPO:     %s\n' "$REPO"
+	[[ $REPO ]] && printf '  REPO:     %s\n' "$REPO"
 	printf '  CIPHER:   %s\n' "$cipher"
 	printf '  PASSWORD: %s\n\n' "$password"
 	printf 'Does this look correct? [Y/n] '
@@ -167,7 +170,7 @@ confirm_rekey() {
 	local answer
 
 	printf '\nThe following configuration will be saved:\n\n'
-	printf '  REPO:     %s\n' "$REPO"
+	[[ $REPO ]] && printf '  REPO:     %s\n' "$REPO"
 	printf '  CIPHER:   %s\n' "$cipher"
 	printf '  PASSWORD: %s\n\n' "$password"
 	printf 'You are about to re-encrypt all encrypted files using new credentials.\n'
@@ -197,9 +200,9 @@ stage_rekeyed_files() {
 	fi
 }
 
-# save helper scripts under the repository's .git/ directory
+# save helper scripts under the repository's git directory
 save_helper_scripts() {
-	[[ ! -d "${REPO}/.git/crypt" ]] && mkdir "${REPO}/.git/crypt"
+	[[ ! -d "${GIT_DIR}/crypt" ]] && mkdir "${GIT_DIR}/crypt"
 
 	# The `decryption -> encryption` process on an unchanged file must be
 	# deterministic for everything to work transparently. To do that, the same
@@ -208,7 +211,7 @@ save_helper_scripts() {
 	# (keyed with a combination of the filename and transcrypt password), and
 	# then use the last 16 bytes of that HMAC for the file's unique salt.
 
-	cat <<-'EOF' > "${REPO}/.git/crypt/clean"
+	cat <<-'EOF' > "${GIT_DIR}/crypt/clean"
 		#!/usr/bin/env bash
 		filename=$1
 		# ignore empty files
@@ -230,7 +233,7 @@ save_helper_scripts() {
 		fi
 	EOF
 
-	cat <<-'EOF' > "${REPO}/.git/crypt/smudge"
+	cat <<-'EOF' > "${GIT_DIR}/crypt/smudge"
 		#!/usr/bin/env bash
 		tempfile=$(mktemp /tmp/transcrypt.XXXXXX)
 		trap 'rm -f "$tempfile"' EXIT
@@ -239,7 +242,7 @@ save_helper_scripts() {
 		tee "$tempfile" | ENC_PASS=$password openssl enc -$cipher -pass env:ENC_PASS -d -a 2> /dev/null || cat "$tempfile"
 	EOF
 
-	cat <<-'EOF' > "${REPO}/.git/crypt/textconv"
+	cat <<-'EOF' > "${GIT_DIR}/crypt/textconv"
 		#!/usr/bin/env bash
 		filename=$1
 		# ignore empty files
@@ -252,11 +255,11 @@ save_helper_scripts() {
 
 	# make scripts executable
 	for script in {clean,smudge,textconv}; do
-		chmod 0755 "${REPO}/.git/crypt/${script}"
+		chmod 0755 "${GIT_DIR}/crypt/${script}"
 	done
 }
 
-# write the configuration to the repository's .git/config
+# write the configuration to the repository's git config
 save_configuration() {
 	save_helper_scripts
 
@@ -266,10 +269,10 @@ save_configuration() {
 	git config transcrypt.password "$password"
 
 	# write the filter settings
-	git config filter.crypt.clean '"$(git rev-parse --show-toplevel)"/.git/crypt/clean %f'
-	git config filter.crypt.smudge '"$(git rev-parse --show-toplevel)"/.git/crypt/smudge'
+	git config filter.crypt.clean '"$(git rev-parse --git-dir)"/crypt/clean %f'
+	git config filter.crypt.smudge '"$(git rev-parse --git-dir)"/crypt/smudge'
 	git config filter.crypt.required 'true'
-	git config diff.crypt.textconv '"$(git rev-parse --show-toplevel)"/.git/crypt/textconv'
+	git config diff.crypt.textconv '"$(git rev-parse --git-dir)"/crypt/textconv'
 	git config diff.crypt.cachetextconv 'true'
 	git config diff.crypt.binary 'true'
 	git config merge.renormalize 'true'
@@ -292,7 +295,7 @@ display_configuration() {
 	printf "  transcrypt -c %s -p '%s'\n" "$current_cipher" "$escaped_password"
 }
 
-# remove transcrypt-related settings from the repository's .git/config
+# remove transcrypt-related settings from the repository's git config
 clean_gitconfig() {
 	git config --remove-section transcrypt
 	git config --remove-section filter.crypt
@@ -372,9 +375,9 @@ uninstall_transcrypt() {
 
 		# remove helper scripts
 		for script in {clean,smudge,textconv}; do
-			[[ -f "${REPO}/.git/crypt/${script}" ]] && rm "${REPO}/.git/crypt/${script}"
+			[[ -f "${GIT_DIR}/crypt/${script}" ]] && rm "${GIT_DIR}/crypt/${script}"
 		done
-		[[ -d "${REPO}/.git/crypt" ]] && rmdir "${REPO}/.git/crypt"
+		[[ -d "${GIT_DIR}/crypt" ]] && rmdir "${GIT_DIR}/crypt"
 
 		# touch all encrypted files to prevent stale stat info
 		local encrypted_files=$(git ls-crypt)
@@ -446,20 +449,20 @@ export_gpg() {
 
 	local current_cipher=$(git config --get --local transcrypt.cipher)
 	local current_password=$(git config --get --local transcrypt.password)
-	[[ ! -d "${REPO}/.git/crypt" ]] && mkdir "${REPO}/.git/crypt"
+	[[ ! -d "${GIT_DIR}/crypt" ]] && mkdir "${GIT_DIR}/crypt"
 
 	local gpg_encrypt_cmd="gpg --batch --recipient $gpg_recipient --trust-model always --yes --armor --quiet --encrypt -"
-	printf 'password=%s\ncipher=%s\n' "$current_password" "$current_cipher" | $gpg_encrypt_cmd > "${REPO}/.git/crypt/${gpg_recipient}.asc"
-	printf "The transcrypt configuration has been encrypted and exported to:\n%s/.git/crypt/%s.asc\n" "$REPO" "$gpg_recipient"
+	printf 'password=%s\ncipher=%s\n' "$current_password" "$current_cipher" | $gpg_encrypt_cmd > "${GIT_DIR}/crypt/${gpg_recipient}.asc"
+	printf "The transcrypt configuration has been encrypted and exported to:\n%s/crypt/%s.asc\n" "$GIT_DIR" "$gpg_recipient"
 }
 
 # import password and cipher from a gpg encrypted file
 import_gpg() {
 	local path
-	if [[ -f "${REPO}/.git/crypt/${gpg_import_file}" ]]; then
-		path="${REPO}/.git/crypt/${gpg_import_file}"
-	elif [[ -f "${REPO}/.git/crypt/${gpg_import_file}.asc" ]]; then
-		path="${REPO}/.git/crypt/${gpg_import_file}.asc"
+	if [[ -f "${GIT_DIR}/crypt/${gpg_import_file}" ]]; then
+		path="${GIT_DIR}/crypt/${gpg_import_file}"
+	elif [[ -f "${GIT_DIR}/crypt/${gpg_import_file}.asc" ]]; then
+		path="${GIT_DIR}/crypt/${gpg_import_file}.asc"
 	elif [[ ! -f $gpg_import_file ]]; then
 		die 1 'the file "%s" does not exist' "$gpg_import_file"
 	else

--- a/transcrypt
+++ b/transcrypt
@@ -193,10 +193,11 @@ get_password() {
 confirm_configuration() {
 	local answer
 
-	printf '\nThe following configuration will be saved:\n\n'
+	printf '\nRepository metadata:\n\n'
 	[[ $REPO ]] && printf '  GIT_WORK_TREE:  %s\n' "$REPO"
 	printf '  GIT_DIR:        %s\n' "$GIT_DIR"
 	printf '  GIT_ATTRIBUTES: %s\n\n' "$GIT_ATTRIBUTES"
+	printf 'The following configuration will be saved:\n\n'
 	printf '  CIPHER:   %s\n' "$cipher"
 	printf '  PASSWORD: %s\n\n' "$password"
 	printf 'Does this look correct? [Y/n] '
@@ -215,10 +216,11 @@ confirm_configuration() {
 confirm_rekey() {
 	local answer
 
-	printf '\nThe following configuration will be saved:\n\n'
+	printf '\nRepository metadata:\n\n'
 	[[ $REPO ]] && printf '  GIT_WORK_TREE:  %s\n' "$REPO"
 	printf '  GIT_DIR:        %s\n' "$GIT_DIR"
 	printf '  GIT_ATTRIBUTES: %s\n\n' "$GIT_ATTRIBUTES"
+	printf 'The following configuration will be saved:\n\n'
 	printf '  CIPHER:   %s\n' "$cipher"
 	printf '  PASSWORD: %s\n\n' "$password"
 	printf 'You are about to re-encrypt all encrypted files using new credentials.\n'

--- a/transcrypt
+++ b/transcrypt
@@ -194,7 +194,8 @@ confirm_configuration() {
 	local answer
 
 	printf '\nThe following configuration will be saved:\n\n'
-	[[ $REPO ]] && printf '  REPO:     %s\n' "$REPO"
+	printf '  GIT_DIR:        %s\n' "$GIT_DIR"
+	printf '  GIT_ATTRIBUTES: %s\n\n' "$GIT_ATTRIBUTES"
 	printf '  CIPHER:   %s\n' "$cipher"
 	printf '  PASSWORD: %s\n\n' "$password"
 	printf 'Does this look correct? [Y/n] '
@@ -214,7 +215,8 @@ confirm_rekey() {
 	local answer
 
 	printf '\nThe following configuration will be saved:\n\n'
-	[[ $REPO ]] && printf '  REPO:     %s\n' "$REPO"
+	printf '  GIT_DIR:        %s\n' "$GIT_DIR"
+	printf '  GIT_ATTRIBUTES: %s\n\n' "$GIT_ATTRIBUTES"
 	printf '  CIPHER:   %s\n' "$cipher"
 	printf '  PASSWORD: %s\n\n' "$password"
 	printf 'You are about to re-encrypt all encrypted files using new credentials.\n'
@@ -333,6 +335,8 @@ display_configuration() {
 
 	printf 'The current repository was configured using transcrypt version %s\n' "$CONFIGURED"
 	printf 'and has the following configuration:\n\n'
+	printf '  GIT_DIR:        %s\n' "$GIT_DIR"
+	printf '  GIT_ATTRIBUTES: %s\n\n' "$GIT_ATTRIBUTES"
 	printf '  CIPHER:   %s\n' "$current_cipher"
 	printf '  PASSWORD: %s\n\n' "$current_password"
 	printf 'Copy and paste the following command to initialize a cloned repository:\n\n'

--- a/transcrypt
+++ b/transcrypt
@@ -20,8 +20,16 @@ readonly VERSION='0.9.7'
 # the default cipher to utilize
 readonly DEFAULT_CIPHER='aes-256-cbc'
 
+# regular expression used to test user input
+readonly YES_REGEX='^[Yy]$'
+
+# repository metadata
+
 # whether or not transcrypt is already configured
 readonly CONFIGURED=$(git config --get --local transcrypt.version 2> /dev/null)
+
+# the current git repository's top-level directory
+readonly REPO=$(git rev-parse --show-toplevel 2> /dev/null)
 
 # the current git repository's .git directory
 readonly GIT_DIR=$(git rev-parse --git-dir 2> /dev/null)
@@ -29,11 +37,15 @@ readonly GIT_DIR=$(git rev-parse --git-dir 2> /dev/null)
 # whether or not a HEAD revision exists
 readonly HEAD_EXISTS=$(git rev-parse --verify --quiet HEAD 2> /dev/null)
 
-# the current git repository's top-level directory
-readonly REPO=$(git rev-parse --show-toplevel 2> /dev/null)
+# whether or not the git repository is bare
+readonly IS_BARE=$(git rev-parse --is-bare-repository)
 
-# regular expression used to test user input
-readonly YES_REGEX='^[Yy]$'
+# the current git repository's gitattributes file
+if [[ $IS_BARE == 'true' ]]; then
+	readonly GIT_ATTRIBUTES="${GIT_DIR}/info/attributes"
+else
+	readonly GIT_ATTRIBUTES="${REPO}/.gitattributes"
+fi
 
 
 ##### Functions
@@ -76,7 +88,7 @@ run_safety_checks() {
 
 	# ensure the repository is clean (if it has a HEAD revision) so we can force
 	# checkout files without the destruction of uncommitted changes
-	if [[ $requires_clean_repo ]] && [[ $HEAD_EXISTS ]]; then
+	if [[ $requires_clean_repo ]] && [[ $HEAD_EXISTS ]] && [[ $IS_BARE == 'false' ]]; then
 		# check if the repo is dirty
 		if ! git diff-index --quiet HEAD; then
 			die 1 'the repo is dirty; commit or stash your changes before running transcrypt'
@@ -189,7 +201,7 @@ confirm_rekey() {
 # automatically stage rekeyed files in preparation for the user to commit them
 stage_rekeyed_files() {
 	local encrypted_files=$(git ls-crypt)
-	if [[ $encrypted_files ]]; then
+	if [[ $encrypted_files ]] && [[ $IS_BARE == 'false' ]]; then
 		# touch all encrypted files to prevent stale stat info
 		cd "$REPO" || die 1 'could not change into the "%s" directory' "$REPO"
 		touch $encrypted_files
@@ -314,7 +326,7 @@ clean_gitconfig() {
 # or it will encrypt locally decrypted files if you've just flushed the credentials
 force_checkout() {
 	# make sure a HEAD revision exists
-	if [[ $HEAD_EXISTS ]]; then
+	if [[ $HEAD_EXISTS ]] && [[ $IS_BARE == 'false' ]]; then
 		# this would normally delete uncommitted changes in the working directory,
 		# but we already made sure the repo was clean during the safety checks
 		cd "$REPO" || die 1 'could not change into the "%s" directory' "$REPO"
@@ -381,7 +393,7 @@ uninstall_transcrypt() {
 
 		# touch all encrypted files to prevent stale stat info
 		local encrypted_files=$(git ls-crypt)
-		if [[ $encrypted_files ]]; then
+		if [[ $encrypted_files ]] && [[ $IS_BARE == 'false' ]]; then
 			cd "$REPO" || die 1 'could not change into the "%s" directory' "$REPO"
 			touch $encrypted_files
 		fi
@@ -395,13 +407,13 @@ uninstall_transcrypt() {
 			git config --remove-section alias
 		fi
 
-		# remove any defined crypt patterns in .gitattributes
+		# remove any defined crypt patterns in gitattributes
 		case $OSTYPE in
 			darwin*)
-				sed -i '' '/filter=crypt diff=crypt[ \t]*$/d' "${REPO}/.gitattributes"
+				sed -i '' '/filter=crypt diff=crypt[ \t]*$/d' "$GIT_ATTRIBUTES"
 				;;
 			linux*)
-				sed -i '/filter=crypt diff=crypt[ \t]*$/d' "${REPO}/.gitattributes"
+				sed -i '/filter=crypt diff=crypt[ \t]*$/d' "$GIT_ATTRIBUTES"
 				;;
 		esac
 
@@ -413,8 +425,10 @@ uninstall_transcrypt() {
 
 # list all of the currently encrypted files in the repository
 list_files() {
-	cd "$REPO" || die 1 'could not change into the "%s" directory' "$REPO"
-	git ls-files | git check-attr --stdin filter | awk 'BEGIN { FS = ":" }; /crypt$/{ print $1 }'
+	if [[ $IS_BARE == 'false' ]]; then
+		cd "$REPO" || die 1 'could not change into the "%s" directory' "$REPO"
+		git ls-files | git check-attr --stdin filter | awk 'BEGIN { FS = ":" }; /crypt$/{ print $1 }'
+	fi
 }
 
 # show the raw file as stored in the git commit object
@@ -767,8 +781,9 @@ else
 fi
 
 # ensure the git attributes file exists
-if [[ ! -f "${REPO}/.gitattributes" ]]; then
-	printf '#pattern  filter=crypt diff=crypt\n' > "${REPO}/.gitattributes"
+if [[ ! -f $GIT_ATTRIBUTES ]]; then
+	[[ $IS_BARE == 'true' ]] && mkdir -p "${GIT_DIR}/info"
+	printf '#pattern  filter=crypt diff=crypt\n' > "$GIT_ATTRIBUTES"
 fi
 
 printf 'The repository has been successfully configured by transcrypt.\n'

--- a/transcrypt
+++ b/transcrypt
@@ -12,7 +12,7 @@
 # that can be be found in the LICENSE file.
 #
 
-##### Constants
+##### CONSTANTS
 
 # the release version of this script
 readonly VERSION='0.9.7'
@@ -23,7 +23,7 @@ readonly DEFAULT_CIPHER='aes-256-cbc'
 # regular expression used to test user input
 readonly YES_REGEX='^[Yy]$'
 
-# repository metadata
+## Repository Metadata
 
 # whether or not transcrypt is already configured
 readonly CONFIGURED=$(git config --get --local transcrypt.version 2> /dev/null)
@@ -31,24 +31,56 @@ readonly CONFIGURED=$(git config --get --local transcrypt.version 2> /dev/null)
 # the current git repository's top-level directory
 readonly REPO=$(git rev-parse --show-toplevel 2> /dev/null)
 
-# the current git repository's .git directory
-readonly GIT_DIR=$(git rev-parse --git-dir 2> /dev/null)
-
 # whether or not a HEAD revision exists
 readonly HEAD_EXISTS=$(git rev-parse --verify --quiet HEAD 2> /dev/null)
+
+# https://github.com/RichiH/vcsh
+# whether or not the git repository is running under vcsh
+readonly IS_VCSH=$(git config --get --local --bool vcsh.vcsh)
 
 # whether or not the git repository is bare
 readonly IS_BARE=$(git rev-parse --is-bare-repository)
 
+## Git Directory Handling
+
+# print a canonicalized absolute pathname
+realpath() {
+	local path=$1
+	local dirname=$(cd "${path%/*}" 2> /dev/null; pwd -P)
+	local basename=${path##*/}
+	local abspath=$(printf '%s/%s\n' "$dirname" "$basename")
+	if [[ -d $abspath ]]; then
+		printf '%s\n' "$(cd "$abspath"; pwd -P)"
+	elif [[ -d $path ]]; then
+		printf '%s\n' "$dirname"
+	elif [[ -e $abspath ]]; then
+		printf '%s\n' "$abspath"
+	else
+		printf 'invalid path: %s\n' "$path" >&2
+		exit 1
+	fi
+}
+
+# the current git repository's .git directory
+RELATIVE_GIT_DIR=$(git rev-parse --git-dir 2> /dev/null)
+readonly GIT_DIR=$(realpath "$RELATIVE_GIT_DIR")
+
 # the current git repository's gitattributes file
-if [[ $IS_BARE == 'true' ]]; then
+if [[ $IS_VCSH == 'true' ]]; then
+	VCSH_ATTRIBUTES=$(git config --get --local core.attributesfile)
+	if [[ $VCSH_ATTRIBUTES ]]; then
+		readonly GIT_ATTRIBUTES=$VCSH_ATTRIBUTES
+	else
+		readonly GIT_ATTRIBUTES="${GIT_DIR}/info/attributes"
+	fi
+elif [[ $IS_BARE == 'true' ]]; then
 	readonly GIT_ATTRIBUTES="${GIT_DIR}/info/attributes"
 else
 	readonly GIT_ATTRIBUTES="${REPO}/.gitattributes"
 fi
 
 
-##### Functions
+##### FUNCTIONS
 
 # print a message to stderr
 warn() {
@@ -90,7 +122,7 @@ run_safety_checks() {
 	# checkout files without the destruction of uncommitted changes
 	if [[ $requires_clean_repo ]] && [[ $HEAD_EXISTS ]] && [[ $IS_BARE == 'false' ]]; then
 		# check if the repo is dirty
-		if ! git diff-index --quiet HEAD; then
+		if ! git diff-index --quiet HEAD --; then
 			die 1 'the repo is dirty; commit or stash your changes before running transcrypt'
 		fi
 	fi
@@ -329,11 +361,12 @@ force_checkout() {
 	if [[ $HEAD_EXISTS ]] && [[ $IS_BARE == 'false' ]]; then
 		# this would normally delete uncommitted changes in the working directory,
 		# but we already made sure the repo was clean during the safety checks
+		local encrypted_files=$(git ls-crypt)
 		cd "$REPO" || die 1 'could not change into the "%s" directory' "$REPO"
-		for file in $(git ls-crypt); do
+		for file in $encrypted_files; do
 			rm "$file"
 		done
-		git checkout --force HEAD -- $(git ls-crypt) > /dev/null
+		git checkout --force HEAD -- $encrypted_files > /dev/null
 	fi
 }
 
@@ -620,7 +653,7 @@ help() {
 }
 
 
-##### Main
+##### MAIN
 
 # reset all variables that might be set
 cipher=''
@@ -782,7 +815,7 @@ fi
 
 # ensure the git attributes file exists
 if [[ ! -f $GIT_ATTRIBUTES ]]; then
-	[[ $IS_BARE == 'true' ]] && mkdir -p "${GIT_DIR}/info"
+	mkdir -p "${GIT_ATTRIBUTES%/*}"
 	printf '#pattern  filter=crypt diff=crypt\n' > "$GIT_ATTRIBUTES"
 fi
 


### PR DESCRIPTION
Cleaning up the hard-coded references to certain repository paths not only reduces duplication, but allows us to support fancier workflows. By generalizing the `$GIT_DIR` and `$GIT_ATTRIBUTES` paths, we can now:

* configure bare repositories
* configure "fake bare" repositories for use through [vcsh](https://github.com/RichiH/vcsh)
* configure multiple worktrees via [git-workflow](https://github.com/blog/2042-git-2-5-including-multiple-worktrees-and-triangular-workflows)
* support unencrypted archive exporting via [git-archive](https://git-scm.com/docs/git-archive)

The trickiest part of all this was the need for converting relative paths into absolute paths in a reliable manner. External programs exist to do this, but they're not commonly part of the base OS installs for all the platforms I'd like to support. I needed a Bash-only solution...

I ended up writing a `realpath()` function, and it has proven robust in my testing across various workflows thus far, but I suspect that it's the weak link in these changes. To help understand what's going on, transcrypt now displays some key repository metadata as part of the `--display` command.

ping @tvaughan @ariver @KenRud any chance you fellas could test this branch with your desired workflow to see if things work as expected outside of my limited testing environments?