### PR TITLE
Correct spelling of 'ciper' to 'cipher'

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ directory.
              to check if files are encrypted as expected
 
       -e, --export-gpg=RECIPIENT
-             export  the  repository's ciper and password to a file encrypted
+             export  the  repository's cipher and password to a file encrypted
              for a gpg recipient
 
       -i, --import-gpg=FILE

--- a/man/transcrypt.1
+++ b/man/transcrypt.1
@@ -59,7 +59,7 @@ show the raw file as stored in the git commit object; use this to check if files
 .
 .TP
 \fB\-e\fR, \fB\-\-export\-gpg\fR=\fIrecipient\fR
-export the repository\'s ciper and password to a file encrypted for a gpg recipient
+export the repository\'s cipher and password to a file encrypted for a gpg recipient
 .
 .TP
 \fB\-i\fR, \fB\-\-import\-gpg\fR=\fIfile\fR

--- a/man/transcrypt.1.ronn
+++ b/man/transcrypt.1.ronn
@@ -55,7 +55,7 @@ The transcrypt source code and full documentation may be downloaded from
     use this to check if files are encrypted as expected
 
   * `-e`, `--export-gpg`=<recipient>:
-    export the repository's ciper and password to a file encrypted
+    export the repository's cipher and password to a file encrypted
     for a gpg recipient
 
   * `-i`, `--import-gpg`=<file>:

--- a/transcrypt
+++ b/transcrypt
@@ -622,7 +622,7 @@ help() {
 	            to check if files are encrypted as expected
 
 	     -e, --export-gpg=RECIPIENT
-	            export  the  repository's ciper and password to a file encrypted
+	            export  the  repository's cipher and password to a file encrypted
 	            for a gpg recipient
 
 	     -i, --import-gpg=FILE


### PR DESCRIPTION
Corrected in all locations.   Some of these resources may be derived but attempting to be thorough.