### PR TITLE
Fix OpenSSL v1.1+ incompatibility

### DIFF
--- a/transcrypt
+++ b/transcrypt
@@ -136,15 +136,22 @@ run_safety_checks() {
 
 # unset the cipher variable if it is not supported by openssl
 validate_cipher() {
-	local supported=$(openssl list-cipher-commands | grep --line-regexp "$cipher")
+	# Support for OpenSSL versions after and before 1.1.0
+	local list_cipher_commands="openssl list-cipher-commands"
+	if [[ $($list_cipher_commands 2> /dev/null) ]]; then
+		local supported=$(openssl list-cipher-commands | grep --line-regexp "$cipher")
+	else
+		list_cipher_commands="openssl list -cipher-commands"
+		local supported=$(openssl list -cipher-commands | tr -s ' ' '\n' | grep --line-regexp "$cipher")
+	fi
 	if [[ ! $supported ]]; then
 		if [[ $interactive ]]; then
 			printf '"%s" is not a valid cipher; choose one of the following:\n\n' "$cipher"
-			openssl list-cipher-commands | column -c 80
+			$list_cipher_commands | column -c 80
 			printf '\n'
 			unset cipher
 		else
-			die 1 '"%s" is not a valid cipher; see `openssl list-cipher-commands`' "$cipher"
+			die 1 '"%s" is not a valid cipher; see `%s`' "$cipher" "$list_cipher_commands"
 		fi
 	fi
 }


### PR DESCRIPTION
In OpenSSL 1.1, the equivalent of `list-cipher-commands` is now `list -cipher-commands`, and the former is no longer supported.

This fix maintains backwards compatibility by checking which of the commands succeed first, and use the working one in the subsequent code.