### PR TITLE
#56 Use 16 hex characters in salt

### DIFF
--- a/transcrypt
+++ b/transcrypt
@@ -292,7 +292,7 @@ save_helper_scripts() {
 		  else
 		    cipher=$(git config --get --local transcrypt.cipher)
 		    password=$(git config --get --local transcrypt.password)
-		    salt=$(openssl dgst -hmac "${filename}:${password}" -sha256 "$filename" | tail -c 16)
+		    salt=$(openssl dgst -hmac "${filename}:${password}" -sha256 "$filename" | tr -d '\r\n' | tail -c 16)
 		    ENC_PASS=$password openssl enc -$cipher -md MD5 -pass env:ENC_PASS -e -a -S "$salt" -in "$tempfile"
 		  fi
 		fi


### PR DESCRIPTION
- The current salt uses 15 hex characters and the new-line character on
*nix, and 14 hex characters and carriage-return plus new-line characters
on Windows. Stripping both characters in salt-generation makes
the code cross-platform and eliminates the OpenSSL warning that would
otherwise be printed.
- WARNING: This requires re-encrypting secrets because salts change!
- Fixes #56 