### PR TITLE
#55 Suppress warnings during clean

### DIFF
--- a/transcrypt
+++ b/transcrypt
@@ -293,7 +293,7 @@ save_helper_scripts() {
 		    cipher=$(git config --get --local transcrypt.cipher)
 		    password=$(git config --get --local transcrypt.password)
 		    salt=$(openssl dgst -hmac "${filename}:${password}" -sha256 "$filename" | tail -c 16)
-		    ENC_PASS=$password openssl enc -$cipher -md MD5 -pass env:ENC_PASS -e -a -S "$salt" -in "$tempfile"
+		    ENC_PASS=$password openssl enc -$cipher -md MD5 -pass env:ENC_PASS -e -a -S "$salt" -in "$tempfile" 2> /dev/null
 		  fi
 		fi
 	EOF


### PR DESCRIPTION
- OpenSSL 1.1.1 and later issues warnings with the current clean script.
These have now been disabled by piping stderr to /dev/null similar to
how it's done in smudge and textconv.
- Fixes #55 