### PR TITLE
fix warning and improve encrypt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea/**
+
+transcrypt.iml

--- a/transcrypt
+++ b/transcrypt
@@ -293,7 +293,7 @@ save_helper_scripts() {
 		    cipher=$(git config --get --local transcrypt.cipher)
 		    password=$(git config --get --local transcrypt.password)
 		    salt=$(openssl dgst -hmac "${filename}:${password}" -sha256 "$filename" | tail -c 16)
-		    ENC_PASS=$password openssl enc -$cipher -iter 128 -md sha-1 -pass env:ENC_PASS -e -a -S "$salt" -in "$tempfile"
+		    ENC_PASS=$password openssl enc -$cipher -iter 128 -md sha1 -pass env:ENC_PASS -e -a -S "$salt" -in "$tempfile"
 		  fi
 		fi
 	EOF
@@ -304,7 +304,7 @@ save_helper_scripts() {
 		trap 'rm -f "$tempfile"' EXIT
 		cipher=$(git config --get --local transcrypt.cipher)
 		password=$(git config --get --local transcrypt.password)
-		tee "$tempfile" | ENC_PASS=$password openssl enc -$cipher -iter 128 -md sha-1 -pass env:ENC_PASS -d -a 2> /dev/null ||
+		tee "$tempfile" | ENC_PASS=$password openssl enc -$cipher -iter 128 -md sha1 -pass env:ENC_PASS -d -a 2> /dev/null ||
 		cat "$tempfile"
 	EOF
 
@@ -315,7 +315,7 @@ save_helper_scripts() {
 		if [[ -s $filename ]]; then
 		  cipher=$(git config --get --local transcrypt.cipher)
 		  password=$(git config --get --local transcrypt.password)
-		  ENC_PASS=$password openssl enc -$cipher -iter 128-md sha-1 -pass env:ENC_PASS -d -a -in "$filename" 2> /dev/null ||
+		  ENC_PASS=$password openssl enc -$cipher -iter 128-md sha1 -pass env:ENC_PASS -d -a -in "$filename" 2> /dev/null ||
 		  cat "$filename"
 		fi
 	EOF

--- a/transcrypt
+++ b/transcrypt
@@ -293,7 +293,7 @@ save_helper_scripts() {
 		    cipher=$(git config --get --local transcrypt.cipher)
 		    password=$(git config --get --local transcrypt.password)
 		    salt=$(openssl dgst -hmac "${filename}:${password}" -sha256 "$filename" | tail -c 16)
-		    ENC_PASS=$password openssl enc -$cipher -md sha-1 -pass env:ENC_PASS -e -a -S "$salt" -in "$tempfile"
+		    ENC_PASS=$password openssl enc -$cipher -iter 128 -md sha-1 -pass env:ENC_PASS -e -a -S "$salt" -in "$tempfile"
 		  fi
 		fi
 	EOF
@@ -304,8 +304,8 @@ save_helper_scripts() {
 		trap 'rm -f "$tempfile"' EXIT
 		cipher=$(git config --get --local transcrypt.cipher)
 		password=$(git config --get --local transcrypt.password)
-		tee "$tempfile" | ENC_PASS=$password openssl enc -$cipher -md sha-1 -pass env:ENC_PASS -d -a 2> /dev/null || cat
-		"$tempfile"
+		tee "$tempfile" | ENC_PASS=$password openssl enc -$cipher -iter 128 -md sha-1 -pass env:ENC_PASS -d -a 2> /dev/null ||
+		cat "$tempfile"
 	EOF
 
 	cat <<-'EOF' > "${GIT_DIR}/crypt/textconv"
@@ -315,8 +315,8 @@ save_helper_scripts() {
 		if [[ -s $filename ]]; then
 		  cipher=$(git config --get --local transcrypt.cipher)
 		  password=$(git config --get --local transcrypt.password)
-		  ENC_PASS=$password openssl enc -$cipher -md sha-1 -pass env:ENC_PASS -d -a -in "$filename" 2> /dev/null || cat
-		  "$filename"
+		  ENC_PASS=$password openssl enc -$cipher -iter 128-md sha-1 -pass env:ENC_PASS -d -a -in "$filename" 2> /dev/null ||
+		  cat "$filename"
 		fi
 	EOF
 

--- a/transcrypt
+++ b/transcrypt
@@ -292,7 +292,7 @@ save_helper_scripts() {
 		  else
 		    cipher=$(git config --get --local transcrypt.cipher)
 		    password=$(git config --get --local transcrypt.password)
-		    salt=$(openssl dgst -hmac "${filename}:${password}" -sha256 "$filename" | tail -c 16)
+		    salt=$(openssl dgst -hmac "${filename}:${password}" -sha256 "$filename" | tail -c 17)
 		    ENC_PASS=$password openssl enc -$cipher -iter 128 -md sha1 -pass env:ENC_PASS -e -a -S "$salt" -in "$tempfile"
 		  fi
 		fi

--- a/transcrypt
+++ b/transcrypt
@@ -305,7 +305,7 @@ save_helper_scripts() {
 		cipher=$(git config --get --local transcrypt.cipher)
 		password=$(git config --get --local transcrypt.password)
 		tee "$tempfile" | ENC_PASS=$password openssl enc -$cipher -iter 128 -md sha1 -pass env:ENC_PASS -d -a 2> /dev/null ||
-		cat "$tempfile"
+		 cat "$tempfile"
 	EOF
 
 	cat <<-'EOF' > "${GIT_DIR}/crypt/textconv"
@@ -316,7 +316,7 @@ save_helper_scripts() {
 		  cipher=$(git config --get --local transcrypt.cipher)
 		  password=$(git config --get --local transcrypt.password)
 		  ENC_PASS=$password openssl enc -$cipher -iter 128-md sha1 -pass env:ENC_PASS -d -a -in "$filename" 2> /dev/null ||
-		  cat "$filename"
+		   cat "$filename"
 		fi
 	EOF
 

--- a/transcrypt
+++ b/transcrypt
@@ -293,7 +293,7 @@ save_helper_scripts() {
 		    cipher=$(git config --get --local transcrypt.cipher)
 		    password=$(git config --get --local transcrypt.password)
 		    salt=$(openssl dgst -hmac "${filename}:${password}" -sha256 "$filename" | tail -c 16)
-		    ENC_PASS=$password openssl enc -$cipher -md MD5 -pass env:ENC_PASS -e -a -S "$salt" -in "$tempfile"
+		    ENC_PASS=$password openssl enc -$cipher -md sha-1 -pass env:ENC_PASS -e -a -S "$salt" -in "$tempfile"
 		  fi
 		fi
 	EOF
@@ -304,7 +304,8 @@ save_helper_scripts() {
 		trap 'rm -f "$tempfile"' EXIT
 		cipher=$(git config --get --local transcrypt.cipher)
 		password=$(git config --get --local transcrypt.password)
-		tee "$tempfile" | ENC_PASS=$password openssl enc -$cipher -md MD5 -pass env:ENC_PASS -d -a 2> /dev/null || cat "$tempfile"
+		tee "$tempfile" | ENC_PASS=$password openssl enc -$cipher -md sha-1 -pass env:ENC_PASS -d -a 2> /dev/null || cat
+		"$tempfile"
 	EOF
 
 	cat <<-'EOF' > "${GIT_DIR}/crypt/textconv"
@@ -314,7 +315,8 @@ save_helper_scripts() {
 		if [[ -s $filename ]]; then
 		  cipher=$(git config --get --local transcrypt.cipher)
 		  password=$(git config --get --local transcrypt.password)
-		  ENC_PASS=$password openssl enc -$cipher -md MD5 -pass env:ENC_PASS -d -a -in "$filename" 2> /dev/null || cat "$filename"
+		  ENC_PASS=$password openssl enc -$cipher -md sha-1 -pass env:ENC_PASS -d -a -in "$filename" 2> /dev/null || cat
+		  "$filename"
 		fi
 	EOF
 

--- a/transcrypt
+++ b/transcrypt
@@ -193,7 +193,7 @@ get_password() {
 		# generate a random password if the user answered yes;
 		# otherwise prompt the user for a password
 		if [[ $answer =~ $YES_REGEX ]] || [[ ! $answer ]]; then
-			local password_length=30
+			local password_length=32
 			local random_base64=$(openssl rand -base64 $password_length)
 			password=$random_base64
 		else


### PR DESCRIPTION
fix #56 
fix #59 

1. fix waring like above
2. import default password 30 to 32,as 2 power 5
3. -md5 change to sha1 to improve encrypt(sha1 is more stronger than md5)

maybe it is not incompatible with last versions

I have simply test it, it works well