### PR TITLE
PROPOSAL: Add support for multiple passphrase "contexts" in one repo

### DIFF
--- a/.github/workflows/run-bats-core-tests.yml
+++ b/.github/workflows/run-bats-core-tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-16.04, ubuntu-18.04]
+        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
 
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/README.md
+++ b/README.md
@@ -322,8 +322,21 @@ Please use:
 Tests are written using [bats-core](https://github.com/bats-core/bats-core)
 version of "Bash Automated Testing System" and stored in the _tests/_ directory.
 
-To run the tests:
+To run the tests locally:
 
 - [install bats-core](https://github.com/bats-core/bats-core#installation)
 - run all tests with: `bats tests/`
 - run an individual test with e.g: `./tests/test_help.bats`
+
+To run the tests in Docker:
+
+- install Docker
+- `cd tests/`
+- check available test targets (Docker services): `docker-compose ps`
+- build images for all test targets: `docker-compose build`
+  - or for a specific test target: `docker-compose build ubuntu-20.04`
+- run tests on all targets (non-zero exit codes means fail): `docker-compose up`
+  - or run tests on a specific target: `docker-compose run --rm ubuntu-20.04`
+- to manually run and debug tests:
+  - run shell in a specfic target: `docker-compose run --rm ubuntu-20.04`
+  - run tests selectively with something like: `bats tests/test_init.bats -t`

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ by running the `--display` command line option:
     The current repository was configured using transcrypt v0.2.0
     and has the following configuration:
 
+      CONTEXT:  default
       CIPHER:   aes-256-cbc
       PASSWORD: correct horse battery staple
 

--- a/man/transcrypt.1.ronn
+++ b/man/transcrypt.1.ronn
@@ -65,6 +65,15 @@ The transcrypt source code and full documentation may be downloaded from
   * `-i`, `--import-gpg`=<file>:
     import the password and cipher from a gpg encrypted file
 
+  * `-C`, `--context`=<context_name>
+    name for a context that can use a different passphrase and cipher
+    from the 'default' context; use this advanced option, to permit
+    encrypting different files with different passphrases
+
+  * `--list-contexts`
+    list all contexts configured in the repository, and warn about
+    incompletely configured contexts.
+
   * `-v`, `--version`:
     print the version information
 
@@ -101,6 +110,29 @@ force a checkout of any existing encrypted files in order to decrypt them.
 If the origin repository has just rekeyed, all clones should flush their
 transcrypt credentials, fetch and merge the new encrypted files via Git, and
 then re-configure transcrypt with the new credentials.
+
+You can use context names to encrypt files for different audiences with
+different passwords, such as normal users versus admins. The 'default'
+context applies unless you set a context name.
+To add a context, initialise transcrypt with the context's name and add
+a .gitattributes pattern including 'crypt-context=<name>'. For example:
+
+    # Initialise a new context "admin", and set a different password
+    $ transcrypt --context=admin
+
+    # Add a pattern with 'crypt-context=admin' to .gitattributes
+    $ echo >> .gitattributes \\
+    'admin.txt filter=crypt diff=crypt merge=crypt crypt-context=admin'
+
+    # Add and commit your secret and .gitattribute files
+    $ git add .gitattributes admin.txt
+    $ git commit -m "Add encrypted admin-only file in 'admin' context"
+
+    # List all contexts
+    $ transcrypt --list-contexts
+
+    # Display a context's cipher and password
+    $ transcrypt --context=admin --display
 
 ## AUTHOR
 

--- a/tests/Dockerfile.ubuntu
+++ b/tests/Dockerfile.ubuntu
@@ -2,7 +2,10 @@ ARG version
 
 FROM ubuntu:$version
 
-# Install git
+# Install git, but PPA tool first so we can get newer git on 16.04
+RUN apt-get update \
+    && apt-get install -y software-properties-common \
+    && add-apt-repository ppa:git-core/ppa
 RUN apt-get update \
     && apt-get install -y git bsdmainutils
 

--- a/tests/Dockerfile.ubuntu
+++ b/tests/Dockerfile.ubuntu
@@ -1,0 +1,18 @@
+ARG version
+
+FROM ubuntu:$version
+
+# Install git
+RUN apt-get update \
+    && apt-get install -y git bsdmainutils
+
+# Install and set up bats-core
+RUN git clone https://github.com/bats-core/bats-core.git /tmp/bats-core-repo \
+    && mkdir -p /tmp/bats-core \
+    && bash /tmp/bats-core-repo/install.sh /tmp/bats-core
+RUN ln -s /tmp/bats-core/bin/bats /usr/local/bin/bats
+
+# Need to configure git globally to avoid errors when we create and use
+# temporary test-specific Git repos fatal: `empty ident name`
+RUN git config --global user.name github-actions-user \
+    && git config --global user.email github-actions-user@example.com

--- a/tests/_test_helper.bash
+++ b/tests/_test_helper.bash
@@ -66,3 +66,7 @@ function teardown {
   cleanup_all
   popd
 }
+
+function check_repo_is_clean {
+  git diff-index --quiet HEAD --
+}

--- a/tests/_test_helper.bash
+++ b/tests/_test_helper.bash
@@ -40,10 +40,16 @@ function init_transcrypt {
 function encrypt_named_file {
   filename="$1"
   content=$2
+  context=${3:-default}
   if [ "$content" ]; then
     echo "$content" > "$filename"
   fi
-  echo "\"$filename\" filter=crypt diff=crypt merge=crypt" >> .gitattributes
+  if [ "$context" != "default" ]; then
+    context_crypt="$context-crypt"
+  else
+    context_crypt="crypt"
+  fi
+  echo "\"$filename\" filter=${context_crypt} diff=${context_crypt} merge=${context_crypt}" >> .gitattributes
   git add .gitattributes "$filename"
   run git commit -m "Encrypt file \"$filename\""
 }

--- a/tests/_test_helper.bash
+++ b/tests/_test_helper.bash
@@ -44,12 +44,11 @@ function encrypt_named_file {
   if [ "$content" ]; then
     echo "$content" > "$filename"
   fi
-  if [ "$context" != "default" ]; then
-    context_crypt="$context-crypt"
+  if [ "$context" = "default" ]; then
+    echo "\"$filename\" filter=crypt diff=crypt merge=crypt" >> .gitattributes
   else
-    context_crypt="crypt"
+    echo "\"$filename\" filter=crypt diff=crypt merge=crypt crypt-context=$context" >> .gitattributes
   fi
-  echo "\"$filename\" filter=${context_crypt} diff=${context_crypt} merge=${context_crypt}" >> .gitattributes
   git add .gitattributes "$filename"
   run git commit -m "Encrypt file \"$filename\""
 }

--- a/tests/_test_helper.bash
+++ b/tests/_test_helper.bash
@@ -1,36 +1,36 @@
 function init_git_repo {
   # Warn and do nothing if test dir envvar is unset
-  if [[ -z "$BATS_TEST_DIRNAME" ]]; then
-    echo "WARNING: Required envvar \$BATS_TEST_DIRNAME is unset"
+  if [[ -z "$BATS_TMPDIR" ]]; then
+    echo "WARNING: Required envvar \$BATS_TMPDIR is unset"
   # Warn and do nothing if test git repo path already exists
-  elif [[ -e "$BATS_TEST_DIRNAME/.git" ]]; then
-    echo "WARNING: Test repo already exists at $BATS_TEST_DIRNAME/.git"
+  elif [[ -e "$BATS_TMPDIR/.git" ]]; then
+    echo "WARNING: Test repo already exists at $BATS_TMPDIR/.git"
   else
     # Initialise test git repo at the same path as the test files
-    git init "$BATS_TEST_DIRNAME"
+    git init "$BATS_TMPDIR"
     # Flag test git repo as 100% the test one, for safety before later removal
-    touch "$BATS_TEST_DIRNAME"/.git/repo-for-transcrypt-bats-tests
+    touch "$BATS_TMPDIR"/.git/repo-for-transcrypt-bats-tests
   fi
 }
 
 function nuke_git_repo {
   # Warn and do nothing if test dir envvar is unset
-  if [[ -z "$BATS_TEST_DIRNAME" ]]; then
-    echo "WARNING: Required envvar \$BATS_TEST_DIRNAME is unset"
+  if [[ -z "$BATS_TMPDIR" ]]; then
+    echo "WARNING: Required envvar \$BATS_TMPDIR is unset"
   # Warn and do nothing if the test git repo is missing the flag file that
   # ensures it *really* is the test one, as set by the 'init_git_repo' function
-  elif [[ ! -e "$BATS_TEST_DIRNAME/.git/repo-for-transcrypt-bats-tests" ]]; then
-    echo "WARNING: Aborting delete of non-test Git repo at $BATS_TEST_DIRNAME/.git"
+  elif [[ ! -e "$BATS_TMPDIR/.git/repo-for-transcrypt-bats-tests" ]]; then
+    echo "WARNING: Aborting delete of non-test Git repo at $BATS_TMPDIR/.git"
   else
     # Forcibly delete the test git repo
-    rm -fR "$BATS_TEST_DIRNAME"/.git
+    rm -fR "$BATS_TMPDIR"/.git
   fi
 }
 
 function cleanup_all {
   nuke_git_repo
-  rm "$BATS_TEST_DIRNAME"/.gitattributes
-  rm -f "$BATS_TEST_DIRNAME"/sensitive_file
+  rm -f "$BATS_TMPDIR"/.gitattributes
+  rm -f "$BATS_TMPDIR"/sensitive_file
 }
 
 function init_transcrypt {
@@ -54,7 +54,7 @@ function encrypt_named_file {
 }
 
 function setup {
-  pushd "$BATS_TEST_DIRNAME" || exit 1
+  pushd "$BATS_TMPDIR" || exit 1
   init_git_repo
   if [[ ! "$SETUP_SKIP_INIT_TRANSCRYPT" ]]; then
     init_transcrypt

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,0 +1,35 @@
+version: '3.6'
+
+x-base: &base
+  command: bats tests/
+  volumes:
+    - .:/tests/
+    - ../transcrypt:/transcrypt
+  build: &build
+    context: .
+    dockerfile: Dockerfile.ubuntu
+    args:
+      version: 20.04
+
+services:
+
+  ubuntu-16.04:
+    <<: *base
+    build:
+      <<: *build
+      args:
+        version: 16.04
+
+  ubuntu-18.04:
+    <<: *base
+    build:
+      <<: *build
+      args:
+        version: 18.04
+
+  ubuntu-20.04:
+    <<: *base
+    build:
+      <<: *build
+      args:
+        version: 20.04

--- a/tests/test_cleanup.bats
+++ b/tests/test_cleanup.bats
@@ -19,8 +19,8 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/kkWK36bn3fbq5DY2d+JXL2YWoN/eoXA1XJZEk9JS7j/856rXK
   [[ "${output}" = *"+$SECRET_CONTENT" ]]  # Check last line of patch
 
   # Look up notes ref to cached plaintext
-  [[ -f $BATS_TEST_DIRNAME/.git/refs/notes/textconv/crypt ]]
-  cached_plaintext_obj=$(cat "$BATS_TEST_DIRNAME/.git/refs/notes/textconv/crypt")
+  [[ -f $BATS_TMPDIR/.git/refs/notes/textconv/crypt ]]
+  cached_plaintext_obj=$(cat "$BATS_TMPDIR/.git/refs/notes/textconv/crypt")
 
   # Confirm plaintext is cached
   run git show "$cached_plaintext_obj"
@@ -31,7 +31,7 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/kkWK36bn3fbq5DY2d+JXL2YWoN/eoXA1XJZEk9JS7j/856rXK
   git repack
 
   # Flush credentials
-  run ../transcrypt -f --yes
+  run "$BATS_TEST_DIRNAME"/../transcrypt -f --yes
   [[ "$status" -eq 0 ]]
 
   # Confirm working copy file is encrypted
@@ -46,7 +46,7 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/kkWK36bn3fbq5DY2d+JXL2YWoN/eoXA1XJZEk9JS7j/856rXK
   [[ "${output}" = *"+$SECRET_CONTENT_ENC" ]]  # Check last line of patch
 
   # Confirm plaintext cache ref was cleared
-  [[ ! -e $BATS_TEST_DIRNAME/.git/refs/notes/textconv/crypt ]]
+  [[ ! -e $BATS_TMPDIR/.git/refs/notes/textconv/crypt ]]
 
   # Confirm plaintext obj was truly cleared and is no longer visible
   run git show "$cached_plaintext_obj"
@@ -67,8 +67,8 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/kkWK36bn3fbq5DY2d+JXL2YWoN/eoXA1XJZEk9JS7j/856rXK
   [[ "${output}" = *"+$SECRET_CONTENT" ]]  # Check last line of patch
 
   # Look up notes ref to cached plaintext
-  [[ -f $BATS_TEST_DIRNAME/.git/refs/notes/textconv/crypt ]]
-  cached_plaintext_obj=$(cat "$BATS_TEST_DIRNAME/.git/refs/notes/textconv/crypt")
+  [[ -f $BATS_TMPDIR/.git/refs/notes/textconv/crypt ]]
+  cached_plaintext_obj=$(cat "$BATS_TMPDIR/.git/refs/notes/textconv/crypt")
 
   # Confirm plaintext is cached
   run git show "$cached_plaintext_obj"
@@ -79,7 +79,7 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/kkWK36bn3fbq5DY2d+JXL2YWoN/eoXA1XJZEk9JS7j/856rXK
   git repack
 
   # Uninstall
-  run ../transcrypt --uninstall --yes
+  run "$BATS_TEST_DIRNAME"/../transcrypt --uninstall --yes
   [[ "$status" -eq 0 ]]
 
   # Confirm working copy file remains unencrypted (per uninstall contract)
@@ -94,7 +94,7 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/kkWK36bn3fbq5DY2d+JXL2YWoN/eoXA1XJZEk9JS7j/856rXK
   [[ "${output}" = *"+$SECRET_CONTENT_ENC" ]]  # Check last line of patch
 
   # Confirm plaintext cache ref was cleared
-  [[ ! -e $BATS_TEST_DIRNAME/.git/refs/notes/textconv/crypt ]]
+  [[ ! -e $BATS_TMPDIR/.git/refs/notes/textconv/crypt ]]
 
   # Confirm plaintext obj was truly cleared and is no longer visible
   run git show "$cached_plaintext_obj"

--- a/tests/test_contexts.bats
+++ b/tests/test_contexts.bats
@@ -90,8 +90,8 @@ function teardown {
   # Confirm .gitattributes is configured for multiple contexts
   run ../transcrypt --list-contexts
   [ "$status" -eq 0 ]
-  [ "${lines[0]}" = 'default (configured, in .gitattributes)' ]
-  [ "${lines[1]}" = 'super-secret (configured, in .gitattributes)' ]
+  [[ "${output}" = *'default (configured, in .gitattributes)'* ]]
+  [[ "${output}" = *'super-secret (configured, in .gitattributes)'* ]]
 }
 
 @test "contexts: encrypted file contents in multiple context are decrypted in working copy" {
@@ -241,7 +241,7 @@ function teardown {
   # Re-init just super-secret context: its files are decrypted, not default context
   $BATS_TEST_DIRNAME/../transcrypt --context=super-secret --cipher=aes-256-cbc --password=321cba --yes
   run ../transcrypt --list-contexts
-  [ "${lines[1]}" = 'super-secret (configured, in .gitattributes)' ]
+  [[ "${output}" = *'super-secret (configured, in .gitattributes)'* ]]
   run cat super_sensitive_file
   [ "${lines[0]}" = "$SECRET_CONTENT" ]
   run cat sensitive_file
@@ -255,7 +255,7 @@ function teardown {
   # Re-init just default context: its files are decrypted, not super-secret context
   $BATS_TEST_DIRNAME/../transcrypt --cipher=aes-256-cbc --password=abc123 --yes
   run ../transcrypt --list-contexts
-  [ "${lines[0]}" = 'default (configured, in .gitattributes)' ]
+  [[ "${output}" = *'default (configured, in .gitattributes)'* ]]
   run cat sensitive_file
   [ "${lines[0]}" = "$SECRET_CONTENT" ]
   run cat super_sensitive_file

--- a/tests/test_contexts.bats
+++ b/tests/test_contexts.bats
@@ -115,8 +115,8 @@ function teardown {
   # Confirm .gitattributes is not yet configured for multiple contexts
   run ../transcrypt --list-contexts
   [ "$status" -eq 0 ]
-  [ "${lines[0]}" = 'default (configured, not in .gitattributes)' ]
-  [ "${lines[1]}" = 'super-secret (configured, not in .gitattributes)' ]
+  [ "${lines[0]}" = 'default (no patterns in .gitattributes)' ]
+  [ "${lines[1]}" = 'super-secret (no patterns in .gitattributes)' ]
 }
 
 @test "contexts: confirm --list-contexts lists contexts with config status" {
@@ -126,8 +126,8 @@ function teardown {
   # Confirm .gitattributes is configured for multiple contexts
   run ../transcrypt --list-contexts
   [ "$status" -eq 0 ]
-  [[ "${output}" = *'default (configured, in .gitattributes)'* ]]
-  [[ "${output}" = *'super-secret (configured, in .gitattributes)'* ]]
+  [[ "${output}" = *'default'* ]]
+  [[ "${output}" = *'super-secret'* ]]
 }
 
 @test "contexts: encrypted file contents in multiple context are decrypted in working copy" {
@@ -271,13 +271,13 @@ function teardown {
   # Confirm .gitattributes is configured for contexts, but Git is not
   run ../transcrypt --list-contexts
   [ "$status" -eq 0 ]
-  [ "${lines[0]}" = 'default (not configured, in .gitattributes)' ]
-  [ "${lines[1]}" = 'super-secret (not configured, in .gitattributes)' ]
+  [ "${lines[0]}" = 'default (not initialised)' ]
+  [ "${lines[1]}" = 'super-secret (not initialised)' ]
 
   # Re-init just super-secret context: its files are decrypted, not default context
   $BATS_TEST_DIRNAME/../transcrypt --context=super-secret --cipher=aes-256-cbc --password=321cba --yes
   run ../transcrypt --list-contexts
-  [[ "${output}" = *'super-secret (configured, in .gitattributes)'* ]]
+  [[ "${output}" = *'super-secret'* ]]
   run cat super_sensitive_file
   [ "${lines[0]}" = "$SECRET_CONTENT" ]
   run cat sensitive_file
@@ -291,7 +291,7 @@ function teardown {
   # Re-init just default context: its files are decrypted, not super-secret context
   $BATS_TEST_DIRNAME/../transcrypt --cipher=aes-256-cbc --password=abc123 --yes
   run ../transcrypt --list-contexts
-  [[ "${output}" = *'default (configured, in .gitattributes)'* ]]
+  [[ "${output}" = *'default'* ]]
   run cat sensitive_file
   [ "${lines[0]}" = "$SECRET_CONTENT" ]
   run cat super_sensitive_file

--- a/tests/test_contexts.bats
+++ b/tests/test_contexts.bats
@@ -62,8 +62,8 @@ function teardown {
   GIT_DIR=`git rev-parse --git-dir`
 
   [ `git config --get transcrypt.version` = $VERSION ]
-  [ `git config --get transcrypt.super-secret-cipher` = "aes-256-cbc" ]
-  [ `git config --get transcrypt.super-secret-password` = "321cba" ]
+  [ `git config --get transcrypt.super-secret.cipher` = "aes-256-cbc" ]
+  [ `git config --get transcrypt.super-secret.password` = "321cba" ]
 
   # Use --git-common-dir if available (Git post Nov 2014) otherwise --git-dir
   if [ -d $(git rev-parse --git-common-dir) ]; then
@@ -254,7 +254,7 @@ function teardown {
   [ "${lines[0]}" = "$SUPER_SECRET_CONTENT_ENC" ]
 }
 
-@test "contexts: just one of multiple contexts can be configured at a time" {
+@test "contexts: only one of multiple contexts can be configured at a time" {
   # Init transcrypt with encrypted files then reset to be like a new clone
   encrypt_named_file sensitive_file "$SECRET_CONTENT"
   encrypt_named_file super_sensitive_file "$SECRET_CONTENT" "super-secret"
@@ -274,7 +274,7 @@ function teardown {
   [ "${lines[0]}" = 'default (not initialised)' ]
   [ "${lines[1]}" = 'super-secret (not initialised)' ]
 
-  # Re-init just super-secret context: its files are decrypted, not default context
+  # Re-init only super-secret context: its files are decrypted, not default context
   $BATS_TEST_DIRNAME/../transcrypt --context=super-secret --cipher=aes-256-cbc --password=321cba --yes
   run ../transcrypt --list-contexts
   [[ "${output}" = *'super-secret'* ]]
@@ -288,7 +288,7 @@ function teardown {
   git reset --hard
   check_repo_is_clean
 
-  # Re-init just default context: its files are decrypted, not super-secret context
+  # Re-init only default context: its files are decrypted, not super-secret context
   $BATS_TEST_DIRNAME/../transcrypt --cipher=aes-256-cbc --password=abc123 --yes
   run ../transcrypt --list-contexts
   [[ "${output}" = *'default'* ]]

--- a/tests/test_contexts.bats
+++ b/tests/test_contexts.bats
@@ -181,21 +181,21 @@ function teardown {
   [ "${lines[1]}" = "super_sensitive_file" ]
 }
 
-@test "contexts: git ls-default-crypt lists encrypted file for only 'default' context" {
+@test "contexts: git ls-crypt-default lists encrypted file for only 'default' context" {
   encrypt_named_file sensitive_file "$SECRET_CONTENT"
   encrypt_named_file super_sensitive_file "$SECRET_CONTENT" "super-secret"
 
-  run git ls-default-crypt
+  run git ls-crypt-default
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = "sensitive_file" ]
   [ "${lines[1]}" = "" ]
 }
 
-@test "contexts: git ls-super-secret-crypt lists encrypted file for only 'super-secret' context" {
+@test "contexts: git ls-crypt-super-secret lists encrypted file for only 'super-secret' context" {
   encrypt_named_file sensitive_file "$SECRET_CONTENT"
   encrypt_named_file super_sensitive_file "$SECRET_CONTENT" "super-secret"
 
-  run git ls-super-secret-crypt
+  run git ls-crypt-super-secret
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = "super_sensitive_file" ]
   [ "${lines[1]}" = "" ]

--- a/tests/test_contexts.bats
+++ b/tests/test_contexts.bats
@@ -346,3 +346,24 @@ function teardown {
   "$BATS_TEST_DIRNAME"/../transcrypt --context=super-secret --cipher=aes-256-cbc --password=321cba --yes
   "$BATS_TEST_DIRNAME"/../transcrypt --cipher=aes-256-cbc --password=abc123 --yes
 }
+
+@test "contexts: --upgrade retains all context configs" {
+  # Init transcrypt with encrypted files then reset to be like a new clone
+  encrypt_named_file sensitive_file "$SECRET_CONTENT"
+  encrypt_named_file super_sensitive_file "$SECRET_CONTENT" "super-secret"
+
+  # We use context names without warning notes as a surrogate for checking
+  # that the super-secret context is configured and in .gitattributes
+  run "$BATS_TEST_DIRNAME"/../transcrypt --list-contexts
+  [[ "$status" -eq 0 ]]
+  [[ "${lines[0]}" = 'default' ]]
+  [[ "${lines[1]}" = 'super-secret' ]]
+
+  # Upgrade removes and *should* re-create config for all contexts
+  run "$BATS_TEST_DIRNAME"/../transcrypt --upgrade --yes
+
+  run "$BATS_TEST_DIRNAME"/../transcrypt --list-contexts
+  [[ "$status" -eq 0 ]]
+  [[ "${lines[0]}" = 'default' ]]
+  [[ "${lines[1]}" = 'super-secret' ]]
+}

--- a/tests/test_contexts.bats
+++ b/tests/test_contexts.bats
@@ -4,7 +4,7 @@ load $BATS_TEST_DIRNAME/_test_helper.bash
 
 SECRET_CONTENT="My secret content"
 SECRET_CONTENT_ENC="U2FsdGVkX1/kkWK36bn3fbq5DY2d+JXL2YWoN/eoXA1XJZEk9JS7j/856rXK9gPn"
-SUPER_SECRET_CONTENT_ENC="U2FsdGVkX1/kkWK36bn3fbq5DY2d+JXL2YWoN/eoXA1XJZEk9JS7j/856rXK9gPn"
+SUPER_SECRET_CONTENT_ENC="U2FsdGVkX1+dAkIV/LAKXMmqjDNOGoOVK8Rmhw9tUnbR4dwBDglpkXIT3yzYBvoc"
 
 function setup {
   pushd $BATS_TEST_DIRNAME
@@ -30,14 +30,16 @@ function teardown {
   [ `git config --get transcrypt.super-secret-password` = "321cba" ]
 
   # Use --git-common-dir if available (Git post Nov 2014) otherwise --git-dir
-  if [[ -d $(git rev-parse --git-common-dir) ]]; then
-    [[ `git config --get filter.super-secret-crypt.clean` = '"$(git rev-parse --git-common-dir)"/crypt/clean %f' ]]
-    [[ `git config --get filter.super-secret-crypt.smudge` = '"$(git rev-parse --git-common-dir)"/crypt/smudge' ]]
-    [[ `git config --get diff.super-secret-crypt.textconv` = '"$(git rev-parse --git-common-dir)"/crypt/textconv' ]]
+  if [ -d $(git rev-parse --git-common-dir) ]; then
+    [ "$(git config --get filter.super-secret-crypt.clean)" = '"$(git rev-parse --git-common-dir)"/crypt/clean super-secret %f' ]
+    [ "$(git config --get filter.super-secret-crypt.smudge)" = '"$(git rev-parse --git-common-dir)"/crypt/smudge super-secret' ]
+    [ "$(git config --get diff.super-secret-crypt.textconv)" = '"$(git rev-parse --git-common-dir)"/crypt/textconv super-secret' ]
+    [ "$(git config --get merge.super-secret-crypt.driver)" = '"$(git rev-parse --git-common-dir)"/crypt/merge super-secret %O %A %B %L %P' ]
   else
-    [[ `git config --get filter.super-secret-crypt.clean` = '"$(git rev-parse --git-dir)"/crypt/clean %f' ]]
-    [[ `git config --get filter.super-secret-crypt.smudge` = '"$(git rev-parse --git-dir)"/crypt/smudge' ]]
-    [[ `git config --get diff.super-secret-crypt.textconv` = '"$(git rev-parse --git-dir)"/crypt/textconv' ]]
+    [ "$(git config --get filter.super-secret-crypt.clean)" = '"$(git rev-parse --git-dir)"/crypt/clean super-secret %f' ]
+    [ "$(git config --get filter.super-secret-crypt.smudge)" = '"$(git rev-parse --git-dir)"/crypt/smudge super-secret' ]
+    [ "$(git config --get diff.super-secret-crypt.textconv)" = '"$(git rev-parse --git-dir)"/crypt/textconv super-secret' ]
+    [ "$(git config --get merge.super-secret-crypt.driver)" = '"$(git rev-parse --git-dir)"/crypt/merge super-secret %O %A %B %L %P' ]
   fi
 
   [ `git config --get filter.super-secret-crypt.required` = "true" ]
@@ -45,9 +47,22 @@ function teardown {
   [ `git config --get diff.super-secret-crypt.binary` = "true" ]
   [ `git config --get merge.renormalize` = "true" ]
 
-  [[ `git config --get alias.ls-super-secret-crypt` = "!git -c core.quotePath=false ls-files"* ]]
+  [ "$(git config --get alias.ls-crypt)" = "!git -c core.quotePath=false ls-files | git -c core.quotePath=false check-attr --stdin filter | awk 'BEGIN { FS = \":\" }; / ([a-zA-Z][a-zA-Z0-9-]*-)?crypt$/{ print \$1 }'" ]
+}
 
-  [[ `git config --get alias.ls-crypt` = "!git -c core.quotePath=false ls-files"* ]]
+@test "init: show extra context details in --display" {
+  VERSION=`../transcrypt -v | awk '{print $2}'`
+
+  run ../transcrypt -C super-secret --display
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "The current repository was configured using transcrypt version $VERSION" ]
+  [ "${lines[1]}" = "and has the following configuration for context 'super-secret':" ]
+  [ "${lines[5]}" = "  CONTEXT:  super-secret" ]
+  [ "${lines[6]}" = "  CIPHER:   aes-256-cbc" ]
+  [ "${lines[7]}" = "  PASSWORD: 321cba" ]
+  [ "${lines[8]}" = "The repository has 2 contexts: default super-secret" ]
+  [ "${lines[9]}" = "Copy and paste the following command to initialize a cloned repository for context 'super-secret':" ]
+  [ "${lines[10]}" = "  transcrypt -C super-secret -c aes-256-cbc -p '321cba'" ]
 }
 
 @test "contexts: encrypt a file in default and 'super-secret' contexts" {
@@ -60,7 +75,15 @@ function teardown {
   [ "${lines[2]}" = '"super_sensitive_file" filter=super-secret-crypt diff=super-secret-crypt merge=super-secret-crypt' ]
 }
 
-@test "contexts: confirm --list-contexts lists context with config status" {
+@test "contexts: confirm --list-contexts lists configured contexts not yet in .gitattributes" {
+  # Confirm .gitattributes is not yet configured for multiple contexts
+  run ../transcrypt --list-contexts
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = 'default (configured, not in .gitattributes)' ]
+  [ "${lines[1]}" = 'super-secret (configured, not in .gitattributes)' ]
+}
+
+@test "contexts: confirm --list-contexts lists contexts with config status" {
   encrypt_named_file sensitive_file "$SECRET_CONTENT"
   encrypt_named_file super_sensitive_file "$SECRET_CONTENT" "super-secret"
 
@@ -73,7 +96,7 @@ function teardown {
 
 @test "contexts: encrypted file contents in multiple context are decrypted in working copy" {
   encrypt_named_file sensitive_file "$SECRET_CONTENT"
-  encrypt_named_file super_sensitive_file "$SECRET_CONTENT" "super_secret"
+  encrypt_named_file super_sensitive_file "$SECRET_CONTENT" "super-secret"
 
   run cat sensitive_file
   [ "$status" -eq 0 ]
@@ -82,4 +105,159 @@ function teardown {
   run cat super_sensitive_file
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = "$SECRET_CONTENT" ]
+}
+
+@test "contexts: encrypted file contents in multiple contexts are encrypted differently in git (via git show)" {
+  encrypt_named_file sensitive_file "$SECRET_CONTENT"
+  encrypt_named_file super_sensitive_file "$SECRET_CONTENT" "super-secret"
+
+  run git show HEAD:sensitive_file --no-textconv
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "$SECRET_CONTENT_ENC" ]
+
+  run git show HEAD:super_sensitive_file --no-textconv
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "$SUPER_SECRET_CONTENT_ENC" ]
+}
+
+@test "contexts: transcrypt --show-raw shows encrypted content for multiple contexts" {
+  encrypt_named_file sensitive_file "$SECRET_CONTENT"
+  encrypt_named_file super_sensitive_file "$SECRET_CONTENT" "super-secret"
+
+  run ../transcrypt --show-raw sensitive_file
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "==> sensitive_file <==" ]
+  [ "${lines[1]}" = "$SECRET_CONTENT_ENC" ]
+
+  run ../transcrypt --show-raw super_sensitive_file
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "==> super_sensitive_file <==" ]
+  [ "${lines[1]}" = "$SUPER_SECRET_CONTENT_ENC" ]
+}
+
+@test "contexts: git ls-crypt lists encrypted file for all contexts" {
+  encrypt_named_file sensitive_file "$SECRET_CONTENT"
+  encrypt_named_file super_sensitive_file "$SECRET_CONTENT" "super-secret"
+
+  run git ls-crypt
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "sensitive_file" ]
+  [ "${lines[1]}" = "super_sensitive_file" ]
+}
+
+@test "contexts: git ls-default-crypt lists encrypted file for only 'default' context" {
+  encrypt_named_file sensitive_file "$SECRET_CONTENT"
+  encrypt_named_file super_sensitive_file "$SECRET_CONTENT" "super-secret"
+
+  run git ls-default-crypt
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "sensitive_file" ]
+  [ "${lines[1]}" = "" ]
+}
+
+@test "contexts: git ls-super-secret-crypt lists encrypted file for only 'super-secret' context" {
+  encrypt_named_file sensitive_file "$SECRET_CONTENT"
+  encrypt_named_file super_sensitive_file "$SECRET_CONTENT" "super-secret"
+
+  run git ls-super-secret-crypt
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "super_sensitive_file" ]
+  [ "${lines[1]}" = "" ]
+}
+
+@test "contexts: transcrypt --list lists encrypted files for all contexts" {
+  encrypt_named_file sensitive_file "$SECRET_CONTENT"
+  encrypt_named_file super_sensitive_file "$SECRET_CONTENT" "super-secret"
+
+  run ../transcrypt --list
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "sensitive_file" ]
+  [ "${lines[1]}" = "super_sensitive_file" ]
+  [ "${lines[2]}" = "" ]
+}
+
+@test "contexts: transcrypt --uninstall leaves decrypted files and repo dirty for all contexts" {
+  encrypt_named_file sensitive_file "$SECRET_CONTENT"
+  encrypt_named_file super_sensitive_file "$SECRET_CONTENT" "super-secret"
+
+  run ../transcrypt --uninstall --yes
+  [ "$status" -eq 0 ]
+
+  run cat sensitive_file
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "$SECRET_CONTENT" ]
+
+  run cat super_sensitive_file
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "$SECRET_CONTENT" ]
+
+  run cat .gitattributes
+  [ "${lines[0]}" = "" ]
+
+  run check_repo_is_clean
+  [ "$status" -ne 0 ]
+}
+
+@test "contexts: git reset after uninstall leaves encrypted file for all contexts" {
+  encrypt_named_file sensitive_file "$SECRET_CONTENT"
+  encrypt_named_file super_sensitive_file "$SECRET_CONTENT" "super-secret"
+
+  ../transcrypt --uninstall --yes
+
+  git reset --hard
+  check_repo_is_clean
+
+  run cat sensitive_file
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" != "$SECRET_CONTENT" ]
+  [ "${lines[0]}" = "$SECRET_CONTENT_ENC" ]
+
+  run cat super_sensitive_file
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" != "$SECRET_CONTENT" ]
+  [ "${lines[0]}" = "$SUPER_SECRET_CONTENT_ENC" ]
+}
+
+@test "contexts: just one of multiple contexts can be configured at a time" {
+  # Init transcrypt with encrypted files then reset to be like a new clone
+  encrypt_named_file sensitive_file "$SECRET_CONTENT"
+  encrypt_named_file super_sensitive_file "$SECRET_CONTENT" "super-secret"
+  ../transcrypt --uninstall --yes
+  git reset --hard
+  check_repo_is_clean
+
+  # Confirm sensitive files for both contexts are encrypted in working dir
+  run cat sensitive_file
+  [ "${lines[0]}" = "$SECRET_CONTENT_ENC" ]
+  run cat super_sensitive_file
+  [ "${lines[0]}" = "$SUPER_SECRET_CONTENT_ENC" ]
+
+  # Confirm .gitattributes is configured for contexts, but Git is not
+  run ../transcrypt --list-contexts
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = 'default (not configured, in .gitattributes)' ]
+  [ "${lines[1]}" = 'super-secret (not configured, in .gitattributes)' ]
+
+  # Re-init just super-secret context: its files are decrypted, not default context
+  $BATS_TEST_DIRNAME/../transcrypt --context=super-secret --cipher=aes-256-cbc --password=321cba --yes
+  run ../transcrypt --list-contexts
+  [ "${lines[1]}" = 'super-secret (configured, in .gitattributes)' ]
+  run cat super_sensitive_file
+  [ "${lines[0]}" = "$SECRET_CONTENT" ]
+  run cat sensitive_file
+  [ "${lines[0]}" = "$SECRET_CONTENT_ENC" ]
+
+  # Reset again
+  ../transcrypt --uninstall --yes
+  git reset --hard
+  check_repo_is_clean
+
+  # Re-init just default context: its files are decrypted, not super-secret context
+  $BATS_TEST_DIRNAME/../transcrypt --cipher=aes-256-cbc --password=abc123 --yes
+  run ../transcrypt --list-contexts
+  [ "${lines[0]}" = 'default (configured, in .gitattributes)' ]
+  run cat sensitive_file
+  [ "${lines[0]}" = "$SECRET_CONTENT" ]
+  run cat super_sensitive_file
+  [ "${lines[0]}" = "$SUPER_SECRET_CONTENT_ENC" ]
 }

--- a/tests/test_contexts.bats
+++ b/tests/test_contexts.bats
@@ -25,7 +25,7 @@ function teardown {
   VERSION=`../transcrypt -v | awk '{print $2}'`
   GIT_DIR=`git rev-parse --git-dir`
 
-  [ `git config --get transcrypt.super-secret-version` = $VERSION ]
+  [ `git config --get transcrypt.version` = $VERSION ]
   [ `git config --get transcrypt.super-secret-cipher` = "aes-256-cbc" ]
   [ `git config --get transcrypt.super-secret-password` = "321cba" ]
 

--- a/tests/test_contexts.bats
+++ b/tests/test_contexts.bats
@@ -254,7 +254,7 @@ function teardown {
   [ "${lines[0]}" = "$SUPER_SECRET_CONTENT_ENC" ]
 }
 
-@test "contexts: only one of multiple contexts can be configured at a time" {
+@test "contexts: any one of multiple contexts works in isolation" {
   # Init transcrypt with encrypted files then reset to be like a new clone
   encrypt_named_file sensitive_file "$SECRET_CONTENT"
   encrypt_named_file super_sensitive_file "$SECRET_CONTENT" "super-secret"
@@ -296,4 +296,13 @@ function teardown {
   [ "${lines[0]}" = "$SECRET_CONTENT" ]
   run cat super_sensitive_file
   [ "${lines[0]}" = "$SUPER_SECRET_CONTENT_ENC" ]
+
+  # Reset again
+  ../transcrypt --uninstall --yes
+  git reset --hard
+  check_repo_is_clean
+
+  # Re-init super-secret then default contexts, to confirm safety check permits this
+  $BATS_TEST_DIRNAME/../transcrypt --context=super-secret --cipher=aes-256-cbc --password=321cba --yes
+  $BATS_TEST_DIRNAME/../transcrypt --cipher=aes-256-cbc --password=abc123 --yes
 }

--- a/tests/test_contexts.bats
+++ b/tests/test_contexts.bats
@@ -7,7 +7,7 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/kkWK36bn3fbq5DY2d+JXL2YWoN/eoXA1XJZEk9JS7j/856rXK
 SUPER_SECRET_CONTENT_ENC="U2FsdGVkX1+dAkIV/LAKXMmqjDNOGoOVK8Rmhw9tUnbR4dwBDglpkXIT3yzYBvoc"
 
 function setup {
-  pushd "$BATS_TEST_DIRNAME" || exit 1
+  pushd "$BATS_TMPDIR" || exit 1
   init_git_repo
   init_transcrypt
 
@@ -17,48 +17,48 @@ function setup {
 
 function teardown {
   cleanup_all
-  rm -f "$BATS_TEST_DIRNAME"/super_sensitive_file
+  rm -f "$BATS_TMPDIR"/super_sensitive_file
   popd || exit 1
 }
 
 @test "contexts: check validation of context names" {
   # Invalid context names
-  run ../transcrypt --context=-ab --cipher=aes-256-cbc --password=none --yes
+  run "$BATS_TEST_DIRNAME"/../transcrypt --context=-ab --cipher=aes-256-cbc --password=none --yes
   [[ "$status" -ne 0 ]]
-  run ../transcrypt --context=1ab --cipher=aes-256-cbc --password=none --yes
+  run "$BATS_TEST_DIRNAME"/../transcrypt --context=1ab --cipher=aes-256-cbc --password=none --yes
   [[ "$status" -ne 0 ]]
-  run ../transcrypt --context=a--b --cipher=aes-256-cbc --password=none --yes
+  run "$BATS_TEST_DIRNAME"/../transcrypt --context=a--b --cipher=aes-256-cbc --password=none --yes
   [[ "$status" -ne 0 ]]
-  run ../transcrypt --context=a- --cipher=aes-256-cbc --password=none --yes
+  run "$BATS_TEST_DIRNAME"/../transcrypt --context=a- --cipher=aes-256-cbc --password=none --yes
   [[ "$status" -ne 0 ]]
-  run ../transcrypt --context=A --cipher=aes-256-cbc --password=none --yes
+  run "$BATS_TEST_DIRNAME"/../transcrypt --context=A --cipher=aes-256-cbc --password=none --yes
   [[ "$status" -ne 0 ]]
-  run ../transcrypt --context=aB --cipher=aes-256-cbc --password=none --yes
+  run "$BATS_TEST_DIRNAME"/../transcrypt --context=aB --cipher=aes-256-cbc --password=none --yes
   [[ "$status" -ne 0 ]]
-  run ../transcrypt --context=a-B --cipher=aes-256-cbc --password=none --yes
+  run "$BATS_TEST_DIRNAME"/../transcrypt --context=a-B --cipher=aes-256-cbc --password=none --yes
   [[ "$status" -ne 0 ]]
 
   # Valid context names
-  run ../transcrypt --context=ab --cipher=aes-256-cbc --password=none --yes
+  run "$BATS_TEST_DIRNAME"/../transcrypt --context=ab --cipher=aes-256-cbc --password=none --yes
   [[ "$status" -eq 0 ]]
-  run ../transcrypt --context=a1 --cipher=aes-256-cbc --password=none --yes
+  run "$BATS_TEST_DIRNAME"/../transcrypt --context=a1 --cipher=aes-256-cbc --password=none --yes
   [[ "$status" -eq 0 ]]
-  run ../transcrypt --context=a-b --cipher=aes-256-cbc --password=none --yes
+  run "$BATS_TEST_DIRNAME"/../transcrypt --context=a-b --cipher=aes-256-cbc --password=none --yes
   [[ "$status" -eq 0 ]]
-  run ../transcrypt --context=a-1 --cipher=aes-256-cbc --password=none --yes
+  run "$BATS_TEST_DIRNAME"/../transcrypt --context=a-1 --cipher=aes-256-cbc --password=none --yes
   [[ "$status" -eq 0 ]]
-  run ../transcrypt --context=a-b-c --cipher=aes-256-cbc --password=none --yes
+  run "$BATS_TEST_DIRNAME"/../transcrypt --context=a-b-c --cipher=aes-256-cbc --password=none --yes
   [[ "$status" -eq 0 ]]
-  run ../transcrypt --context=a-1-c --cipher=aes-256-cbc --password=none --yes
+  run "$BATS_TEST_DIRNAME"/../transcrypt --context=a-1-c --cipher=aes-256-cbc --password=none --yes
   [[ "$status" -eq 0 ]]
-  run ../transcrypt --context=a-b-c-d --cipher=aes-256-cbc --password=none --yes
+  run "$BATS_TEST_DIRNAME"/../transcrypt --context=a-b-c-d --cipher=aes-256-cbc --password=none --yes
   [[ "$status" -eq 0 ]]
-  run ../transcrypt --context=a-1-c-d-2 --cipher=aes-256-cbc --password=none --yes
+  run "$BATS_TEST_DIRNAME"/../transcrypt --context=a-1-c-d-2 --cipher=aes-256-cbc --password=none --yes
   [[ "$status" -eq 0 ]]
 }
 
 @test "contexts: check git config for 'super-secret' context" {
-  VERSION=$(../transcrypt -v | awk '{print $2}')
+  VERSION=$("$BATS_TEST_DIRNAME"/../transcrypt -v | awk '{print $2}')
 
   [[ $(git config --get transcrypt.version) = "$VERSION" ]]
   [[ $(git config --get transcrypt.super-secret.cipher) = "aes-256-cbc" ]]
@@ -87,9 +87,9 @@ function teardown {
 }
 
 @test "init: show extra context details in --display" {
-  VERSION=$(../transcrypt -v | awk '{print $2}')
+  VERSION=$("$BATS_TEST_DIRNAME"/../transcrypt -v | awk '{print $2}')
 
-  run ../transcrypt -C super-secret --display
+  run "$BATS_TEST_DIRNAME"/../transcrypt -C super-secret --display
   [[ "$status" -eq 0 ]]
   [[ "${lines[0]}" = "The current repository was configured using transcrypt version $VERSION" ]]
   [[ "${lines[1]}" = "and has the following configuration for context 'super-secret':" ]]
@@ -103,12 +103,12 @@ function teardown {
 
 @test "contexts: cannot re-init an existing context, fails with error message" {
   # Cannot re-init 'default' context
-  run ../transcrypt --cipher=aes-256-cbc --password=abc123 --yes
+  run "$BATS_TEST_DIRNAME"/../transcrypt --cipher=aes-256-cbc --password=abc123 --yes
   [[ "$status" -ne 0 ]]
   [[ "${lines[0]}" = "transcrypt: the current repository is already configured; see 'transcrypt --display'" ]]
 
   # Cannot re-init a named context
-  run ../transcrypt --context=super-secret --cipher=aes-256-cbc --password=321cba --yes
+  run "$BATS_TEST_DIRNAME"/../transcrypt --context=super-secret --cipher=aes-256-cbc --password=321cba --yes
   [[ "$status" -ne 0 ]]
   [[ "${lines[0]}" = "transcrypt: the current repository is already configured for context 'super-secret'; see 'transcrypt --context=super-secret --display'" ]]
 }
@@ -125,7 +125,7 @@ function teardown {
 
 @test "contexts: confirm --list-contexts lists configured contexts not yet in .gitattributes" {
   # Confirm .gitattributes is not yet configured for multiple contexts
-  run ../transcrypt --list-contexts
+  run "$BATS_TEST_DIRNAME"/../transcrypt --list-contexts
   [[ "$status" -eq 0 ]]
   [[ "${lines[0]}" = 'default (no patterns in .gitattributes)' ]]
   [[ "${lines[1]}" = 'super-secret (no patterns in .gitattributes)' ]]
@@ -136,7 +136,7 @@ function teardown {
   encrypt_named_file super_sensitive_file "$SECRET_CONTENT" "super-secret"
 
   # Confirm .gitattributes is configured for multiple contexts
-  run ../transcrypt --list-contexts
+  run "$BATS_TEST_DIRNAME"/../transcrypt --list-contexts
   [[ "$status" -eq 0 ]]
   [[ "${output}" = *'default'* ]]
   [[ "${output}" = *'super-secret'* ]]
@@ -147,24 +147,24 @@ function teardown {
   encrypt_named_file super_sensitive_file "$SECRET_CONTENT" "super-secret"
 
   # Remove all transcrypt config, including contexts
-  ../transcrypt --uninstall --yes
+  "$BATS_TEST_DIRNAME"/../transcrypt --uninstall --yes
 
   # Don't list contexts when none are known
   echo > .gitattributes
-  run ../transcrypt --list-contexts
+  run "$BATS_TEST_DIRNAME"/../transcrypt --list-contexts
   [[ "$status" -eq 0 ]]
   [[ "${lines[0]}" = '' ]]
 
   # List just super-secret context from .gitattributes
   echo  '"super_sensitive_file" filter=crypt diff=crypt merge=crypt crypt-context=super-secret' > .gitattributes
-  run ../transcrypt --list-contexts
+  run "$BATS_TEST_DIRNAME"/../transcrypt --list-contexts
   [[ "$status" -eq 0 ]]
   [[ "${lines[0]}" = 'super-secret (not initialised)' ]]
   [[ "${lines[1]}" = '' ]]
 
   # List just default context from .gitattributes
   echo  '"sensitive_file" filter=crypt diff=crypt merge=crypt' > .gitattributes
-  run ../transcrypt --list-contexts
+  run "$BATS_TEST_DIRNAME"/../transcrypt --list-contexts
   [[ "$status" -eq 0 ]]
   [[ "${lines[0]}" = 'default (not initialised)' ]]
   [[ "${lines[1]}" = '' ]]
@@ -200,12 +200,12 @@ function teardown {
   encrypt_named_file sensitive_file "$SECRET_CONTENT"
   encrypt_named_file super_sensitive_file "$SECRET_CONTENT" "super-secret"
 
-  run ../transcrypt --show-raw sensitive_file
+  run "$BATS_TEST_DIRNAME"/../transcrypt --show-raw sensitive_file
   [[ "$status" -eq 0 ]]
   [[ "${lines[0]}" = "==> sensitive_file <==" ]]
   [[ "${lines[1]}" = "$SECRET_CONTENT_ENC" ]]
 
-  run ../transcrypt --show-raw super_sensitive_file
+  run "$BATS_TEST_DIRNAME"/../transcrypt --show-raw super_sensitive_file
   [[ "$status" -eq 0 ]]
   [[ "${lines[0]}" = "==> super_sensitive_file <==" ]]
   [[ "${lines[1]}" = "$SUPER_SECRET_CONTENT_ENC" ]]
@@ -245,7 +245,7 @@ function teardown {
   encrypt_named_file sensitive_file "$SECRET_CONTENT"
   encrypt_named_file super_sensitive_file "$SECRET_CONTENT" "super-secret"
 
-  run ../transcrypt --list
+  run "$BATS_TEST_DIRNAME"/../transcrypt --list
   [[ "$status" -eq 0 ]]
   [[ "${lines[0]}" = "sensitive_file" ]]
   [[ "${lines[1]}" = "super_sensitive_file" ]]
@@ -256,7 +256,7 @@ function teardown {
   encrypt_named_file sensitive_file "$SECRET_CONTENT"
   encrypt_named_file super_sensitive_file "$SECRET_CONTENT" "super-secret"
 
-  run ../transcrypt --uninstall --yes
+  run "$BATS_TEST_DIRNAME"/../transcrypt --uninstall --yes
   [[ "$status" -eq 0 ]]
 
   run cat sensitive_file
@@ -278,7 +278,7 @@ function teardown {
   encrypt_named_file sensitive_file "$SECRET_CONTENT"
   encrypt_named_file super_sensitive_file "$SECRET_CONTENT" "super-secret"
 
-  ../transcrypt --uninstall --yes
+  "$BATS_TEST_DIRNAME"/../transcrypt --uninstall --yes
 
   git reset --hard
   check_repo_is_clean
@@ -298,7 +298,7 @@ function teardown {
   # Init transcrypt with encrypted files then reset to be like a new clone
   encrypt_named_file sensitive_file "$SECRET_CONTENT"
   encrypt_named_file super_sensitive_file "$SECRET_CONTENT" "super-secret"
-  ../transcrypt --uninstall --yes
+  "$BATS_TEST_DIRNAME"/../transcrypt --uninstall --yes
   git reset --hard
   check_repo_is_clean
 
@@ -309,14 +309,14 @@ function teardown {
   [[ "${lines[0]}" = "$SUPER_SECRET_CONTENT_ENC" ]]
 
   # Confirm .gitattributes is configured for contexts, but Git is not
-  run ../transcrypt --list-contexts
+  run "$BATS_TEST_DIRNAME"/../transcrypt --list-contexts
   [[ "$status" -eq 0 ]]
   [[ "${lines[0]}" = 'default (not initialised)' ]]
   [[ "${lines[1]}" = 'super-secret (not initialised)' ]]
 
   # Re-init only super-secret context: its files are decrypted, not default context
   "$BATS_TEST_DIRNAME"/../transcrypt --context=super-secret --cipher=aes-256-cbc --password=321cba --yes
-  run ../transcrypt --list-contexts
+  run "$BATS_TEST_DIRNAME"/../transcrypt --list-contexts
   [[ "${output}" = *'super-secret'* ]]
   run cat super_sensitive_file
   [[ "${lines[0]}" = "$SECRET_CONTENT" ]]
@@ -324,13 +324,13 @@ function teardown {
   [[ "${lines[0]}" = "$SECRET_CONTENT_ENC" ]]
 
   # Reset again
-  ../transcrypt --uninstall --yes
+  "$BATS_TEST_DIRNAME"/../transcrypt --uninstall --yes
   git reset --hard
   check_repo_is_clean
 
   # Re-init only default context: its files are decrypted, not super-secret context
   "$BATS_TEST_DIRNAME"/../transcrypt --cipher=aes-256-cbc --password=abc123 --yes
-  run ../transcrypt --list-contexts
+  run "$BATS_TEST_DIRNAME"/../transcrypt --list-contexts
   [[ "${output}" = *'default'* ]]
   run cat sensitive_file
   [[ "${lines[0]}" = "$SECRET_CONTENT" ]]
@@ -338,7 +338,7 @@ function teardown {
   [[ "${lines[0]}" = "$SUPER_SECRET_CONTENT_ENC" ]]
 
   # Reset again
-  ../transcrypt --uninstall --yes
+  "$BATS_TEST_DIRNAME"/../transcrypt --uninstall --yes
   git reset --hard
   check_repo_is_clean
 

--- a/tests/test_contexts.bats
+++ b/tests/test_contexts.bats
@@ -1,0 +1,85 @@
+#!/usr/bin/env bats
+
+load $BATS_TEST_DIRNAME/_test_helper.bash
+
+SECRET_CONTENT="My secret content"
+SECRET_CONTENT_ENC="U2FsdGVkX1/kkWK36bn3fbq5DY2d+JXL2YWoN/eoXA1XJZEk9JS7j/856rXK9gPn"
+SUPER_SECRET_CONTENT_ENC="U2FsdGVkX1/kkWK36bn3fbq5DY2d+JXL2YWoN/eoXA1XJZEk9JS7j/856rXK9gPn"
+
+function setup {
+  pushd $BATS_TEST_DIRNAME
+  init_git_repo
+  init_transcrypt
+
+  # Init transcrypt with 'super-secret' context
+  $BATS_TEST_DIRNAME/../transcrypt --context=super-secret --cipher=aes-256-cbc --password=321cba --yes
+}
+
+function teardown {
+  cleanup_all
+  rm -f $BATS_TEST_DIRNAME/super_sensitive_file
+  popd
+}
+
+@test "contexts: check git config for 'super-secret' context" {
+  VERSION=`../transcrypt -v | awk '{print $2}'`
+  GIT_DIR=`git rev-parse --git-dir`
+
+  [ `git config --get transcrypt.super-secret-version` = $VERSION ]
+  [ `git config --get transcrypt.super-secret-cipher` = "aes-256-cbc" ]
+  [ `git config --get transcrypt.super-secret-password` = "321cba" ]
+
+  # Use --git-common-dir if available (Git post Nov 2014) otherwise --git-dir
+  if [[ -d $(git rev-parse --git-common-dir) ]]; then
+    [[ `git config --get filter.super-secret-crypt.clean` = '"$(git rev-parse --git-common-dir)"/crypt/clean %f' ]]
+    [[ `git config --get filter.super-secret-crypt.smudge` = '"$(git rev-parse --git-common-dir)"/crypt/smudge' ]]
+    [[ `git config --get diff.super-secret-crypt.textconv` = '"$(git rev-parse --git-common-dir)"/crypt/textconv' ]]
+  else
+    [[ `git config --get filter.super-secret-crypt.clean` = '"$(git rev-parse --git-dir)"/crypt/clean %f' ]]
+    [[ `git config --get filter.super-secret-crypt.smudge` = '"$(git rev-parse --git-dir)"/crypt/smudge' ]]
+    [[ `git config --get diff.super-secret-crypt.textconv` = '"$(git rev-parse --git-dir)"/crypt/textconv' ]]
+  fi
+
+  [ `git config --get filter.super-secret-crypt.required` = "true" ]
+  [ `git config --get diff.super-secret-crypt.cachetextconv` = "true" ]
+  [ `git config --get diff.super-secret-crypt.binary` = "true" ]
+  [ `git config --get merge.renormalize` = "true" ]
+
+  [[ `git config --get alias.ls-super-secret-crypt` = "!git -c core.quotePath=false ls-files"* ]]
+
+  [[ `git config --get alias.ls-crypt` = "!git -c core.quotePath=false ls-files"* ]]
+}
+
+@test "contexts: encrypt a file in default and 'super-secret' contexts" {
+  encrypt_named_file sensitive_file "$SECRET_CONTENT"
+  encrypt_named_file super_sensitive_file "$SECRET_CONTENT" "super-secret"
+
+  # Confirm .gitattributes is configured for multiple contexts
+  run cat .gitattributes
+  [ "${lines[1]}" = '"sensitive_file" filter=crypt diff=crypt merge=crypt' ]
+  [ "${lines[2]}" = '"super_sensitive_file" filter=super-secret-crypt diff=super-secret-crypt merge=super-secret-crypt' ]
+}
+
+@test "contexts: confirm --list-contexts lists context with config status" {
+  encrypt_named_file sensitive_file "$SECRET_CONTENT"
+  encrypt_named_file super_sensitive_file "$SECRET_CONTENT" "super-secret"
+
+  # Confirm .gitattributes is configured for multiple contexts
+  run ../transcrypt --list-contexts
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = 'default (configured, in .gitattributes)' ]
+  [ "${lines[1]}" = 'super-secret (configured, in .gitattributes)' ]
+}
+
+@test "contexts: encrypted file contents in multiple context are decrypted in working copy" {
+  encrypt_named_file sensitive_file "$SECRET_CONTENT"
+  encrypt_named_file super_sensitive_file "$SECRET_CONTENT" "super_secret"
+
+  run cat sensitive_file
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "$SECRET_CONTENT" ]
+
+  run cat super_sensitive_file
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "$SECRET_CONTENT" ]
+}

--- a/tests/test_contexts.bats
+++ b/tests/test_contexts.bats
@@ -21,6 +21,42 @@ function teardown {
   popd
 }
 
+@test "contexts: check validation of context names" {
+  # Invalid context names
+  run ../transcrypt --context=-ab --cipher=aes-256-cbc --password=none --yes
+  [ "$status" -ne 0 ]
+  run ../transcrypt --context=1ab --cipher=aes-256-cbc --password=none --yes
+  [ "$status" -ne 0 ]
+  run ../transcrypt --context=a--b --cipher=aes-256-cbc --password=none --yes
+  [ "$status" -ne 0 ]
+  run ../transcrypt --context=a- --cipher=aes-256-cbc --password=none --yes
+  [ "$status" -ne 0 ]
+  run ../transcrypt --context=A --cipher=aes-256-cbc --password=none --yes
+  [ "$status" -ne 0 ]
+  run ../transcrypt --context=aB --cipher=aes-256-cbc --password=none --yes
+  [ "$status" -ne 0 ]
+  run ../transcrypt --context=a-B --cipher=aes-256-cbc --password=none --yes
+  [ "$status" -ne 0 ]
+
+  # Valid context names
+  run ../transcrypt --context=ab --cipher=aes-256-cbc --password=none --yes
+  [ "$status" -eq 0 ]
+  run ../transcrypt --context=a1 --cipher=aes-256-cbc --password=none --yes
+  [ "$status" -eq 0 ]
+  run ../transcrypt --context=a-b --cipher=aes-256-cbc --password=none --yes
+  [ "$status" -eq 0 ]
+  run ../transcrypt --context=a-1 --cipher=aes-256-cbc --password=none --yes
+  [ "$status" -eq 0 ]
+  run ../transcrypt --context=a-b-c --cipher=aes-256-cbc --password=none --yes
+  [ "$status" -eq 0 ]
+  run ../transcrypt --context=a-1-c --cipher=aes-256-cbc --password=none --yes
+  [ "$status" -eq 0 ]
+  run ../transcrypt --context=a-b-c-d --cipher=aes-256-cbc --password=none --yes
+  [ "$status" -eq 0 ]
+  run ../transcrypt --context=a-1-c-d-2 --cipher=aes-256-cbc --password=none --yes
+  [ "$status" -eq 0 ]
+}
+
 @test "contexts: check git config for 'super-secret' context" {
   VERSION=`../transcrypt -v | awk '{print $2}'`
   GIT_DIR=`git rev-parse --git-dir`

--- a/tests/test_contexts.bats
+++ b/tests/test_contexts.bats
@@ -101,6 +101,18 @@ function teardown {
   [[ "${lines[10]}" = "  transcrypt -C super-secret -c aes-256-cbc -p '321cba'" ]]
 }
 
+@test "contexts: cannot re-init an existing context, fails with error message" {
+  # Cannot re-init 'default' context
+  run ../transcrypt --cipher=aes-256-cbc --password=abc123 --yes
+  [[ "$status" -ne 0 ]]
+  [[ "${lines[0]}" = "transcrypt: the current repository is already configured; see 'transcrypt --display'" ]]
+
+  # Cannot re-init a named context
+  run ../transcrypt --context=super-secret --cipher=aes-256-cbc --password=321cba --yes
+  [[ "$status" -ne 0 ]]
+  [[ "${lines[0]}" = "transcrypt: the current repository is already configured for context 'super-secret'; see 'transcrypt --context=super-secret --display'" ]]
+}
+
 @test "contexts: encrypt a file in default and 'super-secret' contexts" {
   encrypt_named_file sensitive_file "$SECRET_CONTENT"
   encrypt_named_file super_sensitive_file "$SECRET_CONTENT" "super-secret"

--- a/tests/test_contexts.bats
+++ b/tests/test_contexts.bats
@@ -31,23 +31,23 @@ function teardown {
 
   # Use --git-common-dir if available (Git post Nov 2014) otherwise --git-dir
   if [ -d $(git rev-parse --git-common-dir) ]; then
-    [ "$(git config --get filter.super-secret-crypt.clean)" = '"$(git rev-parse --git-common-dir)"/crypt/clean super-secret %f' ]
-    [ "$(git config --get filter.super-secret-crypt.smudge)" = '"$(git rev-parse --git-common-dir)"/crypt/smudge super-secret' ]
-    [ "$(git config --get diff.super-secret-crypt.textconv)" = '"$(git rev-parse --git-common-dir)"/crypt/textconv super-secret' ]
-    [ "$(git config --get merge.super-secret-crypt.driver)" = '"$(git rev-parse --git-common-dir)"/crypt/merge super-secret %O %A %B %L %P' ]
+    [ "$(git config --get filter.crypt.clean)" = '"$(git rev-parse --git-common-dir)"/crypt/clean %f' ]
+    [ "$(git config --get filter.crypt.smudge)" = '"$(git rev-parse --git-common-dir)"/crypt/smudge %f' ]
+    [ "$(git config --get diff.crypt.textconv)" = '"$(git rev-parse --git-common-dir)"/crypt/textconv' ]
+    [ "$(git config --get merge.crypt.driver)" = '"$(git rev-parse --git-common-dir)"/crypt/merge %O %A %B %L %P' ]
   else
-    [ "$(git config --get filter.super-secret-crypt.clean)" = '"$(git rev-parse --git-dir)"/crypt/clean super-secret %f' ]
-    [ "$(git config --get filter.super-secret-crypt.smudge)" = '"$(git rev-parse --git-dir)"/crypt/smudge super-secret' ]
-    [ "$(git config --get diff.super-secret-crypt.textconv)" = '"$(git rev-parse --git-dir)"/crypt/textconv super-secret' ]
-    [ "$(git config --get merge.super-secret-crypt.driver)" = '"$(git rev-parse --git-dir)"/crypt/merge super-secret %O %A %B %L %P' ]
+    [ "$(git config --get filter.crypt.clean)" = '"$(git rev-parse --git-dir)"/crypt/clean %f' ]
+    [ "$(git config --get filter.crypt.smudge)" = '"$(git rev-parse --git-dir)"/crypt/smudge %f' ]
+    [ "$(git config --get diff.crypt.textconv)" = '"$(git rev-parse --git-dir)"/crypt/textconv' ]
+    [ "$(git config --get merge.crypt.driver)" = '"$(git rev-parse --git-dir)"/crypt/merge %O %A %B %L %P' ]
   fi
 
-  [ `git config --get filter.super-secret-crypt.required` = "true" ]
-  [ `git config --get diff.super-secret-crypt.cachetextconv` = "true" ]
-  [ `git config --get diff.super-secret-crypt.binary` = "true" ]
+  [ `git config --get filter.crypt.required` = "true" ]
+  [ `git config --get diff.crypt.cachetextconv` = "true" ]
+  [ `git config --get diff.crypt.binary` = "true" ]
   [ `git config --get merge.renormalize` = "true" ]
 
-  [ "$(git config --get alias.ls-crypt)" = "!git -c core.quotePath=false ls-files | git -c core.quotePath=false check-attr --stdin filter | awk 'BEGIN { FS = \":\" }; / ([a-zA-Z][a-zA-Z0-9-]*-)?crypt$/{ print \$1 }'" ]
+  [ "$(git config --get alias.ls-crypt)" = "!git -c core.quotePath=false ls-files | git -c core.quotePath=false check-attr --stdin filter | awk 'BEGIN { FS = \":\" }; / crypt$/{ print \$1 }'" ]
 }
 
 @test "init: show extra context details in --display" {
@@ -72,7 +72,7 @@ function teardown {
   # Confirm .gitattributes is configured for multiple contexts
   run cat .gitattributes
   [ "${lines[1]}" = '"sensitive_file" filter=crypt diff=crypt merge=crypt' ]
-  [ "${lines[2]}" = '"super_sensitive_file" filter=super-secret-crypt diff=super-secret-crypt merge=super-secret-crypt' ]
+  [ "${lines[2]}" = '"super_sensitive_file" filter=crypt diff=crypt merge=crypt crypt-context=super-secret' ]
 }
 
 @test "contexts: confirm --list-contexts lists configured contexts not yet in .gitattributes" {

--- a/tests/test_crypt.bats
+++ b/tests/test_crypt.bats
@@ -5,10 +5,6 @@ load $BATS_TEST_DIRNAME/_test_helper.bash
 SECRET_CONTENT="My secret content"
 SECRET_CONTENT_ENC="U2FsdGVkX1/kkWK36bn3fbq5DY2d+JXL2YWoN/eoXA1XJZEk9JS7j/856rXK9gPn"
 
-function check_repo_is_clean {
-  git diff-index --quiet HEAD --
-}
-
 @test "crypt: git ls-crypt command is available" {
   # No encrypted file yet, so command should work with no output
   run git ls-crypt

--- a/tests/test_crypt.bats
+++ b/tests/test_crypt.bats
@@ -32,7 +32,7 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/kkWK36bn3fbq5DY2d+JXL2YWoN/eoXA1XJZEk9JS7j/856rXK
 
 @test "crypt: transcrypt --show-raw shows encrypted content" {
   encrypt_named_file sensitive_file "$SECRET_CONTENT"
-  run ../transcrypt --show-raw sensitive_file
+  run "$BATS_TEST_DIRNAME"/../transcrypt --show-raw sensitive_file
   [[ "$status" -eq 0 ]]
   [[ "${lines[0]}" = "==> sensitive_file <==" ]]
   [[ "${lines[1]}" = "$SECRET_CONTENT_ENC" ]]
@@ -49,7 +49,7 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/kkWK36bn3fbq5DY2d+JXL2YWoN/eoXA1XJZEk9JS7j/856rXK
 @test "crypt: transcrypt --list lists encrypted file" {
   encrypt_named_file sensitive_file "$SECRET_CONTENT"
 
-  run ../transcrypt --list
+  run "$BATS_TEST_DIRNAME"/../transcrypt --list
   [[ "$status" -eq 0 ]]
   [[ "${lines[0]}" = "sensitive_file" ]]
 }
@@ -57,7 +57,7 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/kkWK36bn3fbq5DY2d+JXL2YWoN/eoXA1XJZEk9JS7j/856rXK
 @test "crypt: transcrypt --uninstall leaves decrypted file and repo dirty" {
   encrypt_named_file sensitive_file "$SECRET_CONTENT"
 
-  run ../transcrypt --uninstall --yes
+  run "$BATS_TEST_DIRNAME"/../transcrypt --uninstall --yes
   [[ "$status" -eq 0 ]]
 
   run cat sensitive_file
@@ -74,7 +74,7 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/kkWK36bn3fbq5DY2d+JXL2YWoN/eoXA1XJZEk9JS7j/856rXK
 @test "crypt: git reset after uninstall leaves encrypted file" {
   encrypt_named_file sensitive_file "$SECRET_CONTENT"
 
-  ../transcrypt --uninstall --yes
+  "$BATS_TEST_DIRNAME"/../transcrypt --uninstall --yes
 
   git reset --hard
   check_repo_is_clean
@@ -110,7 +110,7 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/kkWK36bn3fbq5DY2d+JXL2YWoN/eoXA1XJZEk9JS7j/856rXK
   [[ "${lines[0]}" = "$SECRET_CONTENT_ENC" ]]
 
   # transcrypt --show-raw shows encrypted content
-  run ../transcrypt --show-raw "$FILENAME"
+  run "$BATS_TEST_DIRNAME"/../transcrypt --show-raw "$FILENAME"
   [[ "$status" -eq 0 ]]
   [[ "${lines[0]}" = "==> $FILENAME <==" ]]
   [[ "${lines[1]}" = "$SECRET_CONTENT_ENC" ]]
@@ -121,7 +121,7 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/kkWK36bn3fbq5DY2d+JXL2YWoN/eoXA1XJZEk9JS7j/856rXK
   [[ "${lines[0]}" = "$FILENAME" ]]
 
   # transcrypt --list lists encrypted file"
-  run ../transcrypt --list
+  run "$BATS_TEST_DIRNAME"/../transcrypt --list
   [[ "$status" -eq 0 ]]
   [[ "${lines[0]}" = "$FILENAME" ]]
 
@@ -129,7 +129,7 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/kkWK36bn3fbq5DY2d+JXL2YWoN/eoXA1XJZEk9JS7j/856rXK
 }
 
 @test "crypt: transcrypt --upgrade applies new merge driver" {
-  VERSION=$(../transcrypt -v | awk '{print $2}')
+  VERSION=$("$BATS_TEST_DIRNAME"/../transcrypt -v | awk '{print $2}')
 
   encrypt_named_file sensitive_file "$SECRET_CONTENT"
 
@@ -159,7 +159,7 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/kkWK36bn3fbq5DY2d+JXL2YWoN/eoXA1XJZEk9JS7j/856rXK
   [[ "${lines[0]}" = "$SECRET_CONTENT" ]]
 
   # Perform re-install
-  run ../transcrypt --upgrade --yes
+  run "$BATS_TEST_DIRNAME"/../transcrypt --upgrade --yes
   [[ "$status" -eq 0 ]]
 
   run git config --get --local transcrypt.version
@@ -188,7 +188,7 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/kkWK36bn3fbq5DY2d+JXL2YWoN/eoXA1XJZEk9JS7j/856rXK
 @test "crypt: transcrypt --force handles files missing from working copy" {
   encrypt_named_file sensitive_file "$SECRET_CONTENT"
 
-  ../transcrypt --uninstall --yes
+  "$BATS_TEST_DIRNAME"/../transcrypt --uninstall --yes
 
   # Reset repo to restore .gitattributes file
   git reset --hard
@@ -197,7 +197,7 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/kkWK36bn3fbq5DY2d+JXL2YWoN/eoXA1XJZEk9JS7j/856rXK
   rm sensitive_file
 
   # Re-init with --force should check out deleted secret file
-  ../transcrypt --force --cipher=aes-256-cbc --password=abc123 --yes
+  "$BATS_TEST_DIRNAME"/../transcrypt --force --cipher=aes-256-cbc --password=abc123 --yes
 
   # Check sensitive_file is present and decrypted
   run cat sensitive_file

--- a/tests/test_init.bats
+++ b/tests/test_init.bats
@@ -39,15 +39,15 @@ SETUP_SKIP_INIT_TRANSCRYPT=1
 
   # Use --git-common-dir if available (Git post Nov 2014) otherwise --git-dir
   if [ -d $(git rev-parse --git-common-dir) ]; then
-    [ "$(git config --get filter.crypt.clean)" = '"$(git rev-parse --git-common-dir)"/crypt/clean default %f' ]
-    [ "$(git config --get filter.crypt.smudge)" = '"$(git rev-parse --git-common-dir)"/crypt/smudge default' ]
-    [ "$(git config --get diff.crypt.textconv)" = '"$(git rev-parse --git-common-dir)"/crypt/textconv default' ]
-    [ "$(git config --get merge.crypt.driver)" = '"$(git rev-parse --git-common-dir)"/crypt/merge default %O %A %B %L %P' ]
+    [ "$(git config --get filter.crypt.clean)" = '"$(git rev-parse --git-common-dir)"/crypt/clean %f' ]
+    [ "$(git config --get filter.crypt.smudge)" = '"$(git rev-parse --git-common-dir)"/crypt/smudge %f' ]
+    [ "$(git config --get diff.crypt.textconv)" = '"$(git rev-parse --git-common-dir)"/crypt/textconv' ]
+    [ "$(git config --get merge.crypt.driver)" = '"$(git rev-parse --git-common-dir)"/crypt/merge %O %A %B %L %P' ]
   else
-    [ "$(git config --get filter.crypt.clean)" = '"$(git rev-parse --git-dir)"/crypt/clean default %f' ]
-    [ "$(git config --get filter.crypt.smudge)" = '"$(git rev-parse --git-dir)"/crypt/smudge default' ]
-    [ "$(git config --get diff.crypt.textconv)" = '"$(git rev-parse --git-dir)"/crypt/textconv default' ]
-    [ "$(git config --get merge.crypt.driver)" = '"$(git rev-parse --git-dir)"/crypt/merge default %O %A %B %L %P' ]
+    [ "$(git config --get filter.crypt.clean)" = '"$(git rev-parse --git-dir)"/crypt/clean %f' ]
+    [ "$(git config --get filter.crypt.smudge)" = '"$(git rev-parse --git-dir)"/crypt/smudge %f' ]
+    [ "$(git config --get diff.crypt.textconv)" = '"$(git rev-parse --git-dir)"/crypt/textconv' ]
+    [ "$(git config --get merge.crypt.driver)" = '"$(git rev-parse --git-dir)"/crypt/merge %O %A %B %L %P' ]
   fi
 
   [ `git config --get filter.crypt.required` = "true" ]
@@ -55,7 +55,7 @@ SETUP_SKIP_INIT_TRANSCRYPT=1
   [ `git config --get diff.crypt.binary` = "true" ]
   [ `git config --get merge.renormalize` = "true" ]
 
-  [ "$(git config --get alias.ls-crypt)" = "!git -c core.quotePath=false ls-files | git -c core.quotePath=false check-attr --stdin filter | awk 'BEGIN { FS = \":\" }; / ([a-zA-Z][a-zA-Z0-9-]*-)?crypt$/{ print \$1 }'" ]
+  [ "$(git config --get alias.ls-crypt)" = "!git -c core.quotePath=false ls-files | git -c core.quotePath=false check-attr --stdin filter | awk 'BEGIN { FS = \":\" }; / crypt$/{ print \$1 }'" ]
 }
 
 @test "init: show details for --display" {

--- a/tests/test_init.bats
+++ b/tests/test_init.bats
@@ -84,3 +84,11 @@ SETUP_SKIP_INIT_TRANSCRYPT=1
   [[ "${lines[7]}" = "  PASSWORD: abc123" ]]
   [[ "${lines[9]}" = "  transcrypt -c aes-256-cbc -p 'abc123'" ]]
 }
+
+@test "init: cannot re-init, fails with error message" {
+  init_transcrypt
+
+  run ../transcrypt --cipher=aes-256-cbc --password=abc123 --yes
+  [[ "$status" -ne 0 ]]
+  [[ "${lines[0]}" = "transcrypt: the current repository is already configured; see 'transcrypt --display'" ]]
+}

--- a/tests/test_init.bats
+++ b/tests/test_init.bats
@@ -38,14 +38,16 @@ SETUP_SKIP_INIT_TRANSCRYPT=1
   [ `git config --get transcrypt.password` = "abc123" ]
 
   # Use --git-common-dir if available (Git post Nov 2014) otherwise --git-dir
-  if [[ -d $(git rev-parse --git-common-dir) ]]; then
-    [[ `git config --get filter.crypt.clean` = '"$(git rev-parse --git-common-dir)"/crypt/clean %f' ]]
-    [[ `git config --get filter.crypt.smudge` = '"$(git rev-parse --git-common-dir)"/crypt/smudge' ]]
-    [[ `git config --get diff.crypt.textconv` = '"$(git rev-parse --git-common-dir)"/crypt/textconv' ]]
+  if [ -d $(git rev-parse --git-common-dir) ]; then
+    [ "$(git config --get filter.crypt.clean)" = '"$(git rev-parse --git-common-dir)"/crypt/clean default %f' ]
+    [ "$(git config --get filter.crypt.smudge)" = '"$(git rev-parse --git-common-dir)"/crypt/smudge default' ]
+    [ "$(git config --get diff.crypt.textconv)" = '"$(git rev-parse --git-common-dir)"/crypt/textconv default' ]
+    [ "$(git config --get merge.crypt.driver)" = '"$(git rev-parse --git-common-dir)"/crypt/merge default %O %A %B %L %P' ]
   else
-    [[ `git config --get filter.crypt.clean` = '"$(git rev-parse --git-dir)"/crypt/clean %f' ]]
-    [[ `git config --get filter.crypt.smudge` = '"$(git rev-parse --git-dir)"/crypt/smudge' ]]
-    [[ `git config --get diff.crypt.textconv` = '"$(git rev-parse --git-dir)"/crypt/textconv' ]]
+    [ "$(git config --get filter.crypt.clean)" = '"$(git rev-parse --git-dir)"/crypt/clean default %f' ]
+    [ "$(git config --get filter.crypt.smudge)" = '"$(git rev-parse --git-dir)"/crypt/smudge default' ]
+    [ "$(git config --get diff.crypt.textconv)" = '"$(git rev-parse --git-dir)"/crypt/textconv default' ]
+    [ "$(git config --get merge.crypt.driver)" = '"$(git rev-parse --git-dir)"/crypt/merge default %O %A %B %L %P' ]
   fi
 
   [ `git config --get filter.crypt.required` = "true" ]
@@ -53,7 +55,7 @@ SETUP_SKIP_INIT_TRANSCRYPT=1
   [ `git config --get diff.crypt.binary` = "true" ]
   [ `git config --get merge.renormalize` = "true" ]
 
-  [[ `git config --get alias.ls-crypt` = "!git -c core.quotePath=false ls-files"* ]]
+  [ "$(git config --get alias.ls-crypt)" = "!git -c core.quotePath=false ls-files | git -c core.quotePath=false check-attr --stdin filter | awk 'BEGIN { FS = \":\" }; / ([a-zA-Z][a-zA-Z0-9-]*-)?crypt$/{ print \$1 }'" ]
 }
 
 @test "init: show details for --display" {

--- a/tests/test_init.bats
+++ b/tests/test_init.bats
@@ -9,7 +9,7 @@ SETUP_SKIP_INIT_TRANSCRYPT=1
 
 @test "init: works at all" {
   # Use literal command not function to confirm command works at least once
-  run ../transcrypt --cipher=aes-256-cbc --password=abc123 --yes
+  run "$BATS_TEST_DIRNAME"/../transcrypt --cipher=aes-256-cbc --password=abc123 --yes
   [[ "$status" -eq 0 ]]
   [[ "${lines[0]}" = "The repository has been successfully configured by transcrypt." ]]
 }
@@ -31,7 +31,7 @@ SETUP_SKIP_INIT_TRANSCRYPT=1
 
 @test "init: applies git config" {
   init_transcrypt
-  VERSION=$(../transcrypt -v | awk '{print $2}')
+  VERSION=$("$BATS_TEST_DIRNAME"/../transcrypt -v | awk '{print $2}')
 
   [[ "$(git config --get transcrypt.version)" = "$VERSION" ]]
   [[ "$(git config --get transcrypt.cipher)" = "aes-256-cbc" ]]
@@ -61,9 +61,9 @@ SETUP_SKIP_INIT_TRANSCRYPT=1
 
 @test "init: show details for --display" {
   init_transcrypt
-  VERSION=$(../transcrypt -v | awk '{print $2}')
+  VERSION=$("$BATS_TEST_DIRNAME"/../transcrypt -v | awk '{print $2}')
 
-  run ../transcrypt --display
+  run "$BATS_TEST_DIRNAME"/../transcrypt --display
   [[ "$status" -eq 0 ]]
   [[ "${lines[0]}" = "The current repository was configured using transcrypt version $VERSION" ]]
   [[ "${lines[5]}" = "  CONTEXT:  default" ]]
@@ -74,9 +74,9 @@ SETUP_SKIP_INIT_TRANSCRYPT=1
 
 @test "init: show details for -d" {
   init_transcrypt
-  VERSION=$(../transcrypt -v | awk '{print $2}')
+  VERSION=$("$BATS_TEST_DIRNAME"/../transcrypt -v | awk '{print $2}')
 
-  run ../transcrypt -d
+  run "$BATS_TEST_DIRNAME"/../transcrypt -d
   [[ "$status" -eq 0 ]]
   [[ "${lines[0]}" = "The current repository was configured using transcrypt version $VERSION" ]]
   [[ "${lines[5]}" = "  CONTEXT:  default" ]]
@@ -88,7 +88,7 @@ SETUP_SKIP_INIT_TRANSCRYPT=1
 @test "init: cannot re-init, fails with error message" {
   init_transcrypt
 
-  run ../transcrypt --cipher=aes-256-cbc --password=abc123 --yes
+  run "$BATS_TEST_DIRNAME"/../transcrypt --cipher=aes-256-cbc --password=abc123 --yes
   [[ "$status" -ne 0 ]]
   [[ "${lines[0]}" = "transcrypt: the current repository is already configured; see 'transcrypt --display'" ]]
 }

--- a/tests/test_init.bats
+++ b/tests/test_init.bats
@@ -65,9 +65,10 @@ SETUP_SKIP_INIT_TRANSCRYPT=1
   run ../transcrypt --display
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = "The current repository was configured using transcrypt version $VERSION" ]
-  [ "${lines[5]}" = "  CIPHER:   aes-256-cbc" ]
-  [ "${lines[6]}" = "  PASSWORD: abc123" ]
-  [ "${lines[8]}" = "  transcrypt -c aes-256-cbc -p 'abc123'" ]
+  [ "${lines[5]}" = "  CONTEXT:  default" ]
+  [ "${lines[6]}" = "  CIPHER:   aes-256-cbc" ]
+  [ "${lines[7]}" = "  PASSWORD: abc123" ]
+  [ "${lines[9]}" = "  transcrypt -c aes-256-cbc -p 'abc123'" ]
 }
 
 @test "init: show details for -d" {
@@ -77,7 +78,8 @@ SETUP_SKIP_INIT_TRANSCRYPT=1
   run ../transcrypt -d
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = "The current repository was configured using transcrypt version $VERSION" ]
-  [ "${lines[5]}" = "  CIPHER:   aes-256-cbc" ]
-  [ "${lines[6]}" = "  PASSWORD: abc123" ]
-  [ "${lines[8]}" = "  transcrypt -c aes-256-cbc -p 'abc123'" ]
+  [ "${lines[5]}" = "  CONTEXT:  default" ]
+  [ "${lines[6]}" = "  CIPHER:   aes-256-cbc" ]
+  [ "${lines[7]}" = "  PASSWORD: abc123" ]
+  [ "${lines[9]}" = "  transcrypt -c aes-256-cbc -p 'abc123'" ]
 }

--- a/tests/test_not_inited.bats
+++ b/tests/test_not_inited.bats
@@ -12,34 +12,34 @@ SETUP_SKIP_INIT_TRANSCRYPT=1
 # Operations that should work in a repo not yet initialised
 
 @test "not inited: show help for --help" {
-  run ../transcrypt --help
+  run "$BATS_TEST_DIRNAME"/../transcrypt --help
   [[ "${lines[1]}" = "     transcrypt -- transparently encrypt files within a git repository" ]]
 }
 
 @test "not inited: show help for -h" {
-  run ../transcrypt -h
+  run "$BATS_TEST_DIRNAME"/../transcrypt -h
   [[ "${lines[1]}" = "     transcrypt -- transparently encrypt files within a git repository" ]]
 }
 
 @test "not inited: show version for --version" {
-  VERSION=$(../transcrypt -v | awk '{print $2}')
-  run ../transcrypt --version
+  VERSION=$("$BATS_TEST_DIRNAME"/../transcrypt -v | awk '{print $2}')
+  run "$BATS_TEST_DIRNAME"/../transcrypt --version
   [[ "${lines[0]}" = "transcrypt $VERSION" ]]
 }
 
 @test "not inited: show version for -v" {
-  VERSION=$(../transcrypt -v | awk '{print $2}')
-  run ../transcrypt -v
+  VERSION=$("$BATS_TEST_DIRNAME"/../transcrypt -v | awk '{print $2}')
+  run "$BATS_TEST_DIRNAME"/../transcrypt -v
   [[ "${lines[0]}" = "transcrypt $VERSION" ]]
 }
 
 @test "not inited: no files listed for --list" {
-  run ../transcrypt --list
+  run "$BATS_TEST_DIRNAME"/../transcrypt --list
   [[ "${lines[0]}" = "" ]]
 }
 
 @test "not inited: no files listed for -l" {
-  run ../transcrypt -l
+  run "$BATS_TEST_DIRNAME"/../transcrypt -l
   [[ "${lines[0]}" = "" ]]
 }
 
@@ -47,32 +47,32 @@ SETUP_SKIP_INIT_TRANSCRYPT=1
 # Operations that should not work in a repo not yet initialised
 
 @test "not inited: error on --display" {
-  run ../transcrypt --display
+  run "$BATS_TEST_DIRNAME"/../transcrypt --display
   [[ "$status" -ne 0 ]]
   [[ "${lines[0]}" = "transcrypt: the current repository is not configured" ]]
 }
 
 @test "not inited: error on -d" {
-  run ../transcrypt -d
+  run "$BATS_TEST_DIRNAME"/../transcrypt -d
   [[ "$status" -ne 0 ]]
   [[ "${lines[0]}" = "transcrypt: the current repository is not configured" ]]
 }
 
 @test "not inited: error on --uninstall" {
-  run ../transcrypt --uninstall
+  run "$BATS_TEST_DIRNAME"/../transcrypt --uninstall
   [[ "$status" -ne 0 ]]
   [[ "${lines[0]}" = "transcrypt: the current repository is not configured" ]]
 }
 
 @test "not inited: error on -u" {
-  run ../transcrypt -u
+  run "$BATS_TEST_DIRNAME"/../transcrypt -u
   [[ "$status" -ne 0 ]]
   [[ "${lines[0]}" = "transcrypt: the current repository is not configured" ]]
 }
 
 
 @test "not inited: error on --upgrade" {
-  run ../transcrypt --upgrade
+  run "$BATS_TEST_DIRNAME"/../transcrypt --upgrade
   [[ "$status" -ne 0 ]]
   [[ "${lines[0]}" = "transcrypt: the current repository is not configured" ]]
 }

--- a/transcrypt
+++ b/transcrypt
@@ -1063,8 +1063,9 @@ help() {
 		     a file in your repository, the file  will  be  transparently  encrypted
 		     once you stage and commit it:
 
-		         $ echo 'sensitive_file  filter=crypt diff=crypt merge=crypt' \\
-		            >> .gitattributes
+		         $ echo >> .gitattributes \\
+		         'sensitive_file  filter=crypt diff=crypt merge=crypt'
+
 		         $ git add .gitattributes sensitive_file
 		         $ git commit -m 'Add encrypted version of a sensitive file'
 
@@ -1080,22 +1081,24 @@ help() {
 		     their transcrypt credentials, fetch and merge the new  encrypted  files
 		     via Git, and then re-configure transcrypt with the new credentials.
 
-		     To use multiple passphrases for files with different security contexts,
-		     specify a new  context name  when you initialise  transcrypt or display
-		     credentials. You can list all the contexts configured in the repository
-		     and their status. For example:
+		     You can use context names to encrypt files for different audiences with
+		     different passwords, such as normal users versus admins.  The 'default'
+		     context applies unless you set a context name.
+		     To add a context, initialise transcrypt with the context's name and add
+		     a .gitattributes pattern including 'crypt-context=<name>'. For example:
 
-		         # Initialise a new context "ts" for top-secret file 'plan'
-		         $ transcrypt --context=ts
+		         # Initialise a new context "admin", and set a different password
+		         $ transcrypt --context=admin
 
-		         # Add an extra 'crypt-context=ts' attribute in .gitattributes
-		         $ echo 'plan filter=crypt diff=crypt merge=crypt crypt-context=ts'\\
-		            >> .gitattributes
+		         # Add a pattern with 'crypt-context=admin' to .gitattributes
+		         $ echo >> .gitattributes \\
+		         'admin.txt filter=crypt diff=crypt merge=crypt crypt-context=admin'
 
-		         $ git add .gitattributes plan
-		         $ git commit -m 'Add encrypted plan in top-secret context'
+		         # Add and commit your secret and .gitattribute files
+		         $ git add .gitattributes admin.txt
+		         $ git commit -m "Add encrypted admin-only file in 'admin' context"
 
-		         # List all contexts and their status
+		         # List all contexts
 		         $ transcrypt --list-contexts
 
 		AUTHOR

--- a/transcrypt
+++ b/transcrypt
@@ -634,6 +634,61 @@ import_gpg() {
 	password=$(printf '%s' "$configuration" | grep '^password' | cut -d'=' -f 2-)
 }
 
+get_contexts_from_git_config() {
+	contexts=()
+	config_name=$(git config --local --name-only --list)
+	extract_context_name_regex="transcrypt.(${CONTEXT_REGEX})?-version"
+	for name in $config_name; do
+		if [[ $name =~ 'transcrypt.version' ]]; then
+			contexts+=' default'
+		elif [[ $name =~ $extract_context_name_regex ]]; then
+			contexts+=" ${BASH_REMATCH[1]}"
+		fi
+	done
+	echo $contexts
+}
+
+get_contexts_from_git_attributes() {
+	contexts=()
+	# Capture contents of .gitattributes without comments (leading # hash)
+	attrs=$(cat $GIT_ATTRIBUTES | sed '/^.*#/d')
+	extract_context_name_regex="filter=(${CONTEXT_REGEX})?-crypt"
+	for attr in $attrs; do
+		if [[ $attr =~ 'filter=crypt' ]]; then
+			contexts+=' default'
+		elif [[ $attr =~ $extract_context_name_regex ]]; then
+			contexts+=" ${BASH_REMATCH[1]}"
+		fi
+	done
+	echo $contexts
+}
+
+get_contexts() {
+	combined_contexts="$(get_contexts_from_git_config) $(get_contexts_from_git_attributes)"
+	echo $(printf '%s\n' $combined_contexts | sort -u | tr '\n' ' ')
+}
+
+is_item_in_array() {
+	# Based on https://stackoverflow.com/a/47541882/4970
+	return $(printf '%s\n' $2 | grep -q "^${1}$")
+}
+
+list_contexts() {
+	in_git_config=$(get_contexts_from_git_config)
+	in_git_attributes=$(get_contexts_from_git_attributes)
+	for context in $(get_contexts); do
+		config_desc='not configured'
+		if is_item_in_array $context "${in_git_config[@]}"; then
+			config_desc='configured'
+		fi
+		attr_desc='not in .gitattributes'
+		if is_item_in_array $context "${in_git_attributes[@]}"; then
+			attr_desc='in .gitattributes'
+		fi
+		echo "$context ($config_desc, $attr_desc)"
+	done
+}
+
 # print this script's usage message to stderr
 usage() {
 	cat <<-EOF >&2
@@ -711,6 +766,9 @@ help() {
 		            and cipher from the "default" context. Use this to encrypt
 		            files with more than one passphrase in the same repository.
 
+		     --list-contexts
+		            list all contexts configured in the repository
+
 		     -v, --version
 		            print the version information
 
@@ -785,6 +843,10 @@ while [[ "${1:-}" != '' ]]; do
 		;;
 	--context=*)
 		context=${1#*=}
+		;;
+	--list-contexts)
+		list_contexts
+		exit 0
 		;;
 	-c | --cipher)
 		cipher=$2

--- a/transcrypt
+++ b/transcrypt
@@ -919,6 +919,7 @@ while [[ "${1:-}" != '' ]]; do
 	-s | --show-raw)
 		show_file=$2
 		requires_existing_config='true'
+		shift
 		;;
 	--show-raw=*)
 		show_file=${1#*=}

--- a/transcrypt
+++ b/transcrypt
@@ -513,7 +513,7 @@ save_configuration() {
 
 	# add a git alias for listing encrypted files in specific context, including 'default'
 	if [[ "$CONTEXT" = 'default' ]]; then
-		# The 'ls-default-crypt' alias calls the 'ls-crypt' alias to get all crypt-ed
+		# The 'ls-crypt-default' alias calls the 'ls-crypt' alias to get all crypt-ed
 		# files then filters those to any *without* a 'crypt-context' attr (unspecified).
 		# This is to avoid very difficult processing of multi-line output if we needed
 		# to fetch the two attrs 'filter' and 'crypt-context' from check-attr at once.
@@ -693,7 +693,7 @@ uninstall_transcrypt() {
 		# remove the `git ls-crypt` global alias and each context-specific alias
 		git config --unset alias.ls-crypt
 		for context in $contexts_in_git_config; do
-			git config --unset alias.ls-"${context}"-crypt
+			git config --unset alias.ls-crypt-"${context}"
 		done
 
 		# remove the alias section if it's now empty
@@ -1250,14 +1250,14 @@ if [[ $context ]]; then
 	readonly CONTEXT_TRANSCRYPT_CIPHER=transcrypt.${CONTEXT}-cipher
 	readonly CONTEXT_TRANSCRYPT_PASSWORD=transcrypt.${CONTEXT}-password
 	# For ls-crypt aliases we want one for each context, including 'default'
-	readonly CONTEXT_LS_CRYPT="ls-$CONTEXT-crypt"
+	readonly CONTEXT_LS_CRYPT="ls-crypt-$CONTEXT"
 else
 	readonly CONTEXT='default'
 	readonly CONTEXT_DESC_SUFFIX=''
 	readonly CONTEXT_TRANSCRYPT_CIPHER=transcrypt.cipher
 	readonly CONTEXT_TRANSCRYPT_PASSWORD=transcrypt.password
 	# For ls-crypt aliases we want one for each context, including 'default'
-	readonly CONTEXT_LS_CRYPT="ls-$CONTEXT-crypt"
+	readonly CONTEXT_LS_CRYPT="ls-crypt-$CONTEXT"
 fi
 
 gather_repo_metadata

--- a/transcrypt
+++ b/transcrypt
@@ -24,10 +24,10 @@ readonly DEFAULT_CIPHER='aes-256-cbc'
 # regular expression used to test user input
 readonly YES_REGEX='^[Yy]$'
 
-## Repository Metadata
+# regular expression used to ensure context name is safe for use in git config
+readonly CONTEXT_REGEX='[a-zA-Z][a-zA-Z0-9-]*'
 
-# whether or not transcrypt is already configured
-readonly CONFIGURED=$(git config --get --local transcrypt.version 2>/dev/null)
+## Repository Metadata
 
 # the current git repository's top-level directory
 readonly REPO=$(git rev-parse --show-toplevel 2>/dev/null)
@@ -113,11 +113,21 @@ run_safety_checks() {
 	# validate that we're in a git repository
 	[[ $GIT_DIR ]] || die 'you are not currently in a git repository; did you forget to run "git init"?'
 
+	# Do we have a valid context name?
+	full_context_regex="^${CONTEXT_REGEX}$"
+	if [[ ! $CONTEXT =~ $full_context_regex ]]; then
+		die 1 "context '$CONTEXT' is invalid. Context names must be ASCII with a letter followed by zero or more of letter/number/hyphen"
+	fi
+
 	# exit if transcrypt is not in the required state
+	current_context_desc=''
+	if [[ $CONTEXT != 'default' ]]; then
+		current_context_desc=" for context '$CONTEXT'"
+	fi
 	if [[ $requires_existing_config ]] && [[ ! $CONFIGURED ]]; then
-		die 1 'the current repository is not configured'
+		die 1 "the current repository is not configured${current_context_desc}"
 	elif [[ ! $requires_existing_config ]] && [[ $CONFIGURED ]]; then
-		die 1 'the current repository is already configured; see --display'
+		die 1 "the current repository is already configured${current_context_desc}; see --display"
 	fi
 
 	# check for dependencies
@@ -256,7 +266,7 @@ confirm_rekey() {
 # automatically stage rekeyed files in preparation for the user to commit them
 stage_rekeyed_files() {
 	local encrypted_files
-	encrypted_files=$(git ls-crypt)
+	encrypted_files=$(git ls-crypt-all)
 	if [[ $encrypted_files ]] && [[ $IS_BARE == 'false' ]]; then
 		# touch all encrypted files to prevent stale stat info
 		cd "$REPO" || die 1 'could not change into the "%s" directory' "$REPO"
@@ -283,7 +293,11 @@ save_helper_scripts() {
 
 	cat <<-'EOF' >"${GIT_DIR}/crypt/clean"
 		#!/usr/bin/env bash
-		filename=$1
+		context_prefix=''
+		if [[ $1 != 'default' ]]; then
+		  context_prefix="$1-"
+		fi
+		filename=$2
 		# ignore empty files
 		if [[ -s $filename ]]; then
 		  # cache STDIN to test if it's already encrypted
@@ -295,8 +309,8 @@ save_helper_scripts() {
 		  if [[ $firstbytes == "U2FsdGVk" ]]; then
 		    cat "$tempfile"
 		  else
-		    cipher=$(git config --get --local transcrypt.cipher)
-		    password=$(git config --get --local transcrypt.password)
+		    cipher=$(git config --get --local transcrypt.${context_prefix}cipher)
+		    password=$(git config --get --local transcrypt.${context_prefix}password)
 		    salt=$(openssl dgst -hmac "${filename}:${password}" -sha256 "$filename" | tr -d '\r\n' | tail -c 16)
 		    ENC_PASS=$password openssl enc -$cipher -md MD5 -pass env:ENC_PASS -e -a -S "$salt" -in "$tempfile"
 		  fi
@@ -305,20 +319,28 @@ save_helper_scripts() {
 
 	cat <<-'EOF' >"${GIT_DIR}/crypt/smudge"
 		#!/usr/bin/env bash
+		context_prefix=''
+		if [[ $1 != 'default' ]]; then
+		  context_prefix="$1-"
+		fi
 		tempfile=$(mktemp 2>/dev/null || mktemp -t tmp)
 		trap 'rm -f "$tempfile"' EXIT
-		cipher=$(git config --get --local transcrypt.cipher)
-		password=$(git config --get --local transcrypt.password)
+		cipher=$(git config --get --local transcrypt.${context_prefix}cipher)
+		password=$(git config --get --local transcrypt.${context_prefix}password)
 		tee "$tempfile" | ENC_PASS=$password openssl enc -$cipher -md MD5 -pass env:ENC_PASS -d -a 2>/dev/null || cat "$tempfile"
 	EOF
 
 	cat <<-'EOF' >"${GIT_DIR}/crypt/textconv"
 		#!/usr/bin/env bash
-		filename=$1
+		context_prefix=''
+		if [[ $1 != 'default' ]]; then
+		  context_prefix="$1="
+		fi
+		filename=$2
 		# ignore empty files
 		if [[ -s $filename ]]; then
-		  cipher=$(git config --get --local transcrypt.cipher)
-		  password=$(git config --get --local transcrypt.password)
+		  cipher=$(git config --get --local transcrypt.${context_prefix}cipher)
+		  password=$(git config --get --local transcrypt.${context_prefix}password)
 		  ENC_PASS=$password openssl enc -$cipher -md MD5 -pass env:ENC_PASS -d -a -in "$filename" 2>/dev/null || cat "$filename"
 		fi
 	EOF
@@ -334,54 +356,69 @@ save_configuration() {
 	save_helper_scripts
 
 	# write the encryption info
-	git config transcrypt.version "$VERSION"
-	git config transcrypt.cipher "$cipher"
-	git config transcrypt.password "$password"
+	git config "$CONTEXT_TRANSCRYPT_VERSION" "$VERSION"
+	git config "$CONTEXT_TRANSCRYPT_CIPHER" "$cipher"
+	git config "$CONTEXT_TRANSCRYPT_PASSWORD" "$password"
 
 	# write the filter settings
 	if [[ -d $(git rev-parse --git-common-dir) ]]; then
 		# this allows us to support multiple working trees via git-worktree
 		# ...but the --git-common-dir flag was only added in November 2014
 		# shellcheck disable=SC2016
-		git config filter.crypt.clean '"$(git rev-parse --git-common-dir)"/crypt/clean %f'
+		git config filter.${CONTEXT_CRYPT}.clean '"$(git rev-parse --git-common-dir)"/crypt/clean '$CONTEXT' %f'
 		# shellcheck disable=SC2016
-		git config filter.crypt.smudge '"$(git rev-parse --git-common-dir)"/crypt/smudge'
+		git config filter.${CONTEXT_CRYPT}.smudge '"$(git rev-parse --git-common-dir)"/crypt/smudge '$CONTEXT
 		# shellcheck disable=SC2016
-		git config diff.crypt.textconv '"$(git rev-parse --git-common-dir)"/crypt/textconv'
+		git config diff.${CONTEXT_CRYPT}.textconv '"$(git rev-parse --git-common-dir)"/crypt/textconv '$CONTEXT
 	else
 		# shellcheck disable=SC2016
-		git config filter.crypt.clean '"$(git rev-parse --git-dir)"/crypt/clean %f'
+		git config filter.${CONTEXT_CRYPT}.clean '"$(git rev-parse --git-dir)"/crypt/clean '$CONTEXT ' %f'
 		# shellcheck disable=SC2016
-		git config filter.crypt.smudge '"$(git rev-parse --git-dir)"/crypt/smudge'
+		git config filter.${CONTEXT_CRYPT}.smudge '"$(git rev-parse --git-dir)"/crypt/smudge '$CONTEXT
 		# shellcheck disable=SC2016
-		git config diff.crypt.textconv '"$(git rev-parse --git-dir)"/crypt/textconv'
+		git config diff.${CONTEXT_CRYPT}.textconv '"$(git rev-parse --git-dir)"/crypt/textconv '$CONTEXT
 	fi
-	git config filter.crypt.required 'true'
-	git config diff.crypt.cachetextconv 'true'
-	git config diff.crypt.binary 'true'
+	git config filter.${CONTEXT_CRYPT}.required 'true'
+	git config diff.${CONTEXT_CRYPT}.cachetextconv 'true'
+	git config diff.${CONTEXT_CRYPT}.binary 'true'
 	git config merge.renormalize 'true'
 
-	# add a git alias for listing encrypted files
-	git config alias.ls-crypt "!git ls-files | git check-attr --stdin filter | awk 'BEGIN { FS = \":\" }; /crypt$/{ print \$1 }'"
+	# add a git alias for listing encrypted files in context
+	git config alias.ls-${CONTEXT_CRYPT} "!git ls-files | git check-attr --stdin filter | awk 'BEGIN { FS = \":\" }; / ${CONTEXT_CRYPT}$/{ print \$1 }'"
+
+	# add a git alias for listing ALL encrypted files regardless of context
+	git config alias.ls-crypt-all "!git ls-files | git check-attr --stdin filter | awk 'BEGIN { FS = \":\" }; / (${CONTEXT_REGEX}-)?crypt$/{ print \$1 }'"
 }
 
 # display the current configuration settings
 display_configuration() {
 	local current_cipher
-	current_cipher=$(git config --get --local transcrypt.cipher)
+	current_cipher=$(git config --get --local $CONTEXT_TRANSCRYPT_CIPHER)
 	local current_password
-	current_password=$(git config --get --local transcrypt.password)
+	current_password=$(git config --get --local $CONTEXT_TRANSCRYPT_PASSWORD)
 	local escaped_password=${current_password//\'/\'\\\'\'}
 
+	current_context_desc=''
+	if [[ $CONTEXT != 'default' ]]; then
+		current_context_desc=" for context '$CONTEXT'"
+	fi
+
 	printf 'The current repository was configured using transcrypt version %s\n' "$CONFIGURED"
-	printf 'and has the following configuration:\n\n'
+	printf "and has the following configuration${current_context_desc}:\n\n"
 	[[ ! $REPO ]] || printf '  GIT_WORK_TREE:  %s\n' "$REPO"
 	printf '  GIT_DIR:        %s\n' "$GIT_DIR"
 	printf '  GIT_ATTRIBUTES: %s\n\n' "$GIT_ATTRIBUTES"
+	if [[ $CONTEXT != 'default' ]]; then
+		printf '  CONTEXT:  %s\n' "$CONTEXT"
+	fi
 	printf '  CIPHER:   %s\n' "$current_cipher"
 	printf '  PASSWORD: %s\n\n' "$current_password"
 	printf 'Copy and paste the following command to initialize a cloned repository:\n\n'
-	printf "  transcrypt -c %s -p '%s'\n" "$current_cipher" "$escaped_password"
+	if [[ $CONTEXT != 'default' ]]; then
+		printf "  transcrypt -C $CONTEXT -c %s -p '%s'\n" "$current_cipher" "$escaped_password"
+	else
+		printf "  transcrypt -c %s -p '%s'\n" "$current_cipher" "$escaped_password"
+	fi
 }
 
 # remove transcrypt-related settings from the repository's git config
@@ -390,6 +427,8 @@ clean_gitconfig() {
 	git config --remove-section filter.crypt 2>/dev/null || true
 	git config --remove-section diff.crypt 2>/dev/null || true
 	git config --unset merge.renormalize
+
+	# TODO Remove context-specific config sections
 
 	# remove the merge section if it's now empty
 	local merge_values
@@ -408,7 +447,7 @@ force_checkout() {
 		# this would normally delete uncommitted changes in the working directory,
 		# but we already made sure the repo was clean during the safety checks
 		local encrypted_files
-		encrypted_files=$(git ls-crypt)
+		encrypted_files=$(git ls-$CONTEXT_CRYPT)
 		cd "$REPO" || die 1 'could not change into the "%s" directory' "$REPO"
 		IFS=$'\n'
 		for file in $encrypted_files; do
@@ -475,7 +514,7 @@ uninstall_transcrypt() {
 
 		# touch all encrypted files to prevent stale stat info
 		local encrypted_files
-		encrypted_files=$(git ls-crypt)
+		encrypted_files=$(git ls-crypt-all)
 		if [[ $encrypted_files ]] && [[ $IS_BARE == 'false' ]]; then
 			cd "$REPO" || die 1 'could not change into the "%s" directory' "$REPO"
 			# shellcheck disable=SC2086
@@ -483,7 +522,8 @@ uninstall_transcrypt() {
 		fi
 
 		# remove the `git ls-crypt` alias
-		git config --unset alias.ls-crypt
+		# TODO Remove context-specific ls-*-crypt aliases
+		git config --unset alias.ls-crypt-all
 
 		# remove the alias section if it's now empty
 		local alias_values
@@ -493,6 +533,7 @@ uninstall_transcrypt() {
 		fi
 
 		# remove any defined crypt patterns in gitattributes
+		# TODO Remove context-specific *-crypt patterns
 		case $OSTYPE in
 		darwin*)
 			/usr/bin/sed -i '' '/filter=crypt diff=crypt[ \t]*$/d' "$GIT_ATTRIBUTES"
@@ -527,7 +568,7 @@ show_raw_file() {
 			die 1 'the file "%s" is not currently being tracked by git' "$show_file"
 		fi
 	elif [[ $show_file == '*' ]]; then
-		file_paths=$(git ls-crypt)
+		file_paths=$(git ls-$CONTEXT_CRYPT)
 	else
 		die 1 'the file "%s" does not exist' "$show_file"
 	fi
@@ -552,9 +593,9 @@ export_gpg() {
 	fi
 
 	local current_cipher
-	current_cipher=$(git config --get --local transcrypt.cipher)
+	current_cipher=$(git config --get --local $CONTEXT_TRANSCRYPT_CIPHER)
 	local current_password
-	current_password=$(git config --get --local transcrypt.password)
+	current_password=$(git config --get --local $CONTEXT_TRANSCRYPT_PASSWORD)
 	mkdir -p "${GIT_DIR}/crypt"
 
 	local gpg_encrypt_cmd="gpg --batch --recipient $gpg_recipient --trust-model always --yes --armor --quiet --encrypt -"
@@ -665,6 +706,11 @@ help() {
 		     -i, --import-gpg=FILE
 		            import the password and cipher from a gpg encrypted file
 
+		     -C, --context=CONTEXT
+		            name for a context that can use a different passphrase
+		            and cipher from the "default" context. Use this to encrypt
+		            files with more than one passphrase in the same repository.
+
 		     -v, --version
 		            print the version information
 
@@ -714,6 +760,7 @@ help() {
 ##### MAIN
 
 # reset all variables that might be set
+context=''
 cipher=''
 password=''
 interactive='true'
@@ -732,6 +779,13 @@ requires_clean_repo='true'
 # parse command line options
 while [[ "${1:-}" != '' ]]; do
 	case $1 in
+	-C | --context)
+		context=$2
+		shift
+		;;
+	--context=*)
+		context=${1#*=}
+		;;
 	-c | --cipher)
 		cipher=$2
 		shift
@@ -776,13 +830,11 @@ while [[ "${1:-}" != '' ]]; do
 		;;
 	-s | --show-raw)
 		show_file=$2
-		show_raw_file
-		exit 0
+		requires_existing_config='true'
 		;;
 	--show-raw=*)
 		show_file=${1#*=}
-		show_raw_file
-		exit 0
+		requires_existing_config='true'
 		;;
 	-e | --export-gpg)
 		gpg_recipient=$2
@@ -824,12 +876,34 @@ while [[ "${1:-}" != '' ]]; do
 	shift
 done
 
+## Multi-context support, triggered by optional '--context' command line option
+
+if [[ $context ]]; then
+	readonly CONTEXT=$context
+	readonly CONTEXT_PREFIX="$context-"
+else
+	readonly CONTEXT='default'
+	readonly CONTEXT_PREFIX=''
+fi
+
+readonly CONTEXT_TRANSCRYPT_VERSION=transcrypt.${CONTEXT_PREFIX:-}version
+readonly CONTEXT_TRANSCRYPT_CIPHER=transcrypt.${CONTEXT_PREFIX:-}cipher
+readonly CONTEXT_TRANSCRYPT_PASSWORD=transcrypt.${CONTEXT_PREFIX:-}password
+readonly CONTEXT_CRYPT=${CONTEXT_PREFIX:-}crypt
+
+# whether or not transcrypt is already configured
+readonly CONFIGURED=$(git config --get --local $CONTEXT_TRANSCRYPT_VERSION 2>/dev/null)
+
+
 # always run our safety checks
 run_safety_checks
 
 # in order to keep behavior consistent no matter what order the options were
 # specified in, we must run these here rather than in the case statement above
-if [[ $uninstall ]]; then
+if [[ $show_file ]]; then
+	show_raw_file
+	exit 0
+elif [[ $uninstall ]]; then
 	uninstall_transcrypt
 	exit 0
 elif [[ $display_config ]] && [[ $flush_creds ]]; then

--- a/transcrypt
+++ b/transcrypt
@@ -13,13 +13,6 @@ set -euo pipefail
 # that can be be found in the LICENSE file.
 #
 
-##### Multi-context support via optional 'CONTEXT' envvar
-
-CONFIG_TRANSCRYPT_VERSION=transcrypt.version${CONTEXT:-}
-CONFIG_TRANSCRYPT_CIPHER=transcrypt.cipher${CONTEXT:-}
-CONFIG_TRANSCRYPT_PASSWORD=transcrypt.password${CONTEXT:-}
-CONFIG_CRYPT=crypt${CONTEXT:-}
-
 ##### CONSTANTS
 
 # the release version of this script
@@ -34,7 +27,7 @@ readonly YES_REGEX='^[Yy]$'
 ## Repository Metadata
 
 # whether or not transcrypt is already configured
-readonly CONFIGURED=$(git config --get --local $CONFIG_TRANSCRYPT_VERSION 2>/dev/null)
+readonly CONFIGURED=$(git config --get --local transcrypt.version 2>/dev/null)
 
 # the current git repository's top-level directory
 readonly REPO=$(git rev-parse --show-toplevel 2>/dev/null)
@@ -272,7 +265,7 @@ stage_rekeyed_files() {
 
 # save helper scripts under the repository's git directory
 save_helper_scripts() {
-	mkdir -p "${GIT_DIR}/${CONFIG_CRYPT}"
+	mkdir -p "${GIT_DIR}/crypt"
 
 	# The `decryption -> encryption` process on an unchanged file must be
 	# deterministic for everything to work transparently. To do that, the same
@@ -281,51 +274,51 @@ save_helper_scripts() {
 	# (keyed with a combination of the filename and transcrypt password), and
 	# then use the last 16 bytes of that HMAC for the file's unique salt.
 
-	cat <<-EOF > "${GIT_DIR}/${CONFIG_CRYPT}/clean"
+	cat <<-'EOF' >"${GIT_DIR}/crypt/clean"
 		#!/usr/bin/env bash
-		filename=\$1
+		filename=$1
 		# ignore empty files
-		if [[ -s \$filename ]]; then
+		if [[ -s $filename ]]; then
 		  # cache STDIN to test if it's already encrypted
-		  tempfile=\$(mktemp 2>/dev/null || mktemp -t tmp)
-		  trap 'rm -f "\$tempfile"' EXIT
-		  tee "\$tempfile" &>/dev/null
+		  tempfile=$(mktemp 2>/dev/null || mktemp -t tmp)
+		  trap 'rm -f "$tempfile"' EXIT
+		  tee "$tempfile" &>/dev/null
 		  # the first bytes of an encrypted file are always "Salted" in Base64
-		  read -n 8 firstbytes < "\$tempfile"
-		  if [[ \$firstbytes == "U2FsdGVk" ]]; then
-		    cat "\$tempfile"
+		  read -n 8 firstbytes <"$tempfile"
+		  if [[ $firstbytes == "U2FsdGVk" ]]; then
+		    cat "$tempfile"
 		  else
-		    cipher=\$(git config --get --local ${CONFIG_TRANSCRYPT_CIPHER})
-		    password=\$(git config --get --local ${CONFIG_TRANSCRYPT_PASSWORD})
-		    salt=\$(openssl dgst -hmac "\${filename}:\${password}" -sha256 "\$filename" | tail -c 16)
-		    ENC_PASS=\$password openssl enc -\$cipher -md MD5 -pass env:ENC_PASS -e -a -S "\$salt" -in "\$tempfile"
+		    cipher=$(git config --get --local transcrypt.cipher)
+		    password=$(git config --get --local transcrypt.password)
+		    salt=$(openssl dgst -hmac "${filename}:${password}" -sha256 "$filename" | tr -d '\r\n' | tail -c 16)
+		    ENC_PASS=$password openssl enc -$cipher -md MD5 -pass env:ENC_PASS -e -a -S "$salt" -in "$tempfile"
 		  fi
 		fi
 	EOF
 
-	cat <<-EOF > "${GIT_DIR}/${CONFIG_CRYPT}/smudge"
+	cat <<-'EOF' >"${GIT_DIR}/crypt/smudge"
 		#!/usr/bin/env bash
-		tempfile=\$(mktemp 2>/dev/null || mktemp -t tmp)
-		trap 'rm -f "\$tempfile"' EXIT
-		cipher=\$(git config --get --local ${CONFIG_TRANSCRYPT_CIPHER})
-		password=\$(git config --get --local ${CONFIG_TRANSCRYPT_PASSWORD})
-		tee "\$tempfile" | ENC_PASS=\$password openssl enc -\$cipher -md MD5 -pass env:ENC_PASS -d -a 2>/dev/null || cat "\$tempfile"
+		tempfile=$(mktemp 2>/dev/null || mktemp -t tmp)
+		trap 'rm -f "$tempfile"' EXIT
+		cipher=$(git config --get --local transcrypt.cipher)
+		password=$(git config --get --local transcrypt.password)
+		tee "$tempfile" | ENC_PASS=$password openssl enc -$cipher -md MD5 -pass env:ENC_PASS -d -a 2>/dev/null || cat "$tempfile"
 	EOF
 
-	cat <<-EOF > "${GIT_DIR}/${CONFIG_CRYPT}/textconv"
+	cat <<-'EOF' >"${GIT_DIR}/crypt/textconv"
 		#!/usr/bin/env bash
-		filename=\$1
+		filename=$1
 		# ignore empty files
-		if [[ -s \$filename ]]; then
-		  cipher=\$(git config --get --local ${CONFIG_TRANSCRYPT_CIPHER})
-		  password=\$(git config --get --local ${CONFIG_TRANSCRYPT_PASSWORD})
-		  ENC_PASS=\$password openssl enc -\$cipher -md MD5 -pass env:ENC_PASS -d -a -in "\$filename" 2>/dev/null || cat "\$filename"
+		if [[ -s $filename ]]; then
+		  cipher=$(git config --get --local transcrypt.cipher)
+		  password=$(git config --get --local transcrypt.password)
+		  ENC_PASS=$password openssl enc -$cipher -md MD5 -pass env:ENC_PASS -d -a -in "$filename" 2>/dev/null || cat "$filename"
 		fi
 	EOF
 
 	# make scripts executable
 	for script in {clean,smudge,textconv}; do
-		chmod 0755 "${GIT_DIR}/${CONFIG_CRYPT}/${script}"
+		chmod 0755 "${GIT_DIR}/crypt/${script}"
 	done
 }
 
@@ -334,35 +327,35 @@ save_configuration() {
 	save_helper_scripts
 
 	# write the encryption info
-	git config $CONFIG_TRANSCRYPT_VERSION "$VERSION"
-	git config ${CONFIG_TRANSCRYPT_CIPHER} "$cipher"
-	git config ${CONFIG_TRANSCRYPT_PASSWORD} "$password"
+	git config transcrypt.version "$VERSION"
+	git config transcrypt.cipher "$cipher"
+	git config transcrypt.password "$password"
 
 	# write the filter settings
 	if [[ -d $(git rev-parse --git-common-dir) ]]; then
 		# this allows us to support multiple working trees via git-worktree
 		# ...but the --git-common-dir flag was only added in November 2014
-		git config filter.${CONFIG_CRYPT}.clean '"$(git rev-parse --git-common-dir)"'/${CONFIG_CRYPT}'/clean %f'
-		git config filter.${CONFIG_CRYPT}.smudge '"$(git rev-parse --git-common-dir)"'/${CONFIG_CRYPT}/smudge
-		git config diff.${CONFIG_CRYPT}.textconv '"$(git rev-parse --git-common-dir)"'/${CONFIG_CRYPT}/textconv
+		git config filter.crypt.clean '"$(git rev-parse --git-common-dir)"/crypt/clean %f'
+		git config filter.crypt.smudge '"$(git rev-parse --git-common-dir)"/crypt/smudge'
+		git config diff.crypt.textconv '"$(git rev-parse --git-common-dir)"/crypt/textconv'
 	else
-		git config filter.${CONFIG_CRYPT}.clean '"$(git rev-parse --git-dir)"'/${CONFIG_CRYPT}/clean %f
-		git config filter.${CONFIG_CRYPT}.smudge '"$(git rev-parse --git-dir)"'/${CONFIG_CRYPT}/smudge
-		git config diff.${CONFIG_CRYPT}.textconv '"$(git rev-parse --git-dir)"'/${CONFIG_CRYPT}/textconv
+		git config filter.crypt.clean '"$(git rev-parse --git-dir)"/crypt/clean %f'
+		git config filter.crypt.smudge '"$(git rev-parse --git-dir)"/crypt/smudge'
+		git config diff.crypt.textconv '"$(git rev-parse --git-dir)"/crypt/textconv'
 	fi
-	git config filter.${CONFIG_CRYPT}.required 'true'
-	git config diff.${CONFIG_CRYPT}.cachetextconv 'true'
-	git config diff.${CONFIG_CRYPT}.binary 'true'
+	git config filter.crypt.required 'true'
+	git config diff.crypt.cachetextconv 'true'
+	git config diff.crypt.binary 'true'
 	git config merge.renormalize 'true'
 
 	# add a git alias for listing encrypted files
-	git config alias.ls-crypt "!git ls-files | git check-attr --stdin filter | awk 'BEGIN { FS = \":\" }; /crypt(-[a-zA-Z]+)?$/{ print \$1 }'"
+	git config alias.ls-crypt "!git ls-files | git check-attr --stdin filter | awk 'BEGIN { FS = \":\" }; /crypt$/{ print \$1 }'"
 }
 
 # display the current configuration settings
 display_configuration() {
-	local current_cipher=$(git config --get --local ${CONFIG_TRANSCRYPT_CIPHER})
-	local current_password=$(git config --get --local ${CONFIG_TRANSCRYPT_PASSWORD})
+	local current_cipher=$(git config --get --local transcrypt.cipher)
+	local current_password=$(git config --get --local transcrypt.password)
 	local escaped_password=${current_password//\'/\'\\\'\'}
 
 	printf 'The current repository was configured using transcrypt version %s\n' "$CONFIGURED"
@@ -379,8 +372,8 @@ display_configuration() {
 # remove transcrypt-related settings from the repository's git config
 clean_gitconfig() {
 	git config --remove-section transcrypt 2>/dev/null || true
-	git config --remove-section filter.${CONFIG_CRYPT} 2>/dev/null || true
-	git config --remove-section diff.${CONFIG_CRYPT} 2>/dev/null || true
+	git config --remove-section filter.crypt 2>/dev/null || true
+	git config --remove-section diff.crypt 2>/dev/null || true
 	git config --unset merge.renormalize
 
 	# remove the merge section if it's now empty
@@ -459,9 +452,9 @@ uninstall_transcrypt() {
 
 		# remove helper scripts
 		for script in {clean,smudge,textconv}; do
-			[[ ! -f "${GIT_DIR}/${CONFIG_CRYPT}/${script}" ]] || rm "${GIT_DIR}/${CONFIG_CRYPT}/${script}"
+			[[ ! -f "${GIT_DIR}/crypt/${script}" ]] || rm "${GIT_DIR}/crypt/${script}"
 		done
-		[[ ! -d "${GIT_DIR}/${CONFIG_CRYPT}" ]] || rmdir "${GIT_DIR}/${CONFIG_CRYPT}"
+		[[ ! -d "${GIT_DIR}/crypt" ]] || rmdir "${GIT_DIR}/crypt"
 
 		# touch all encrypted files to prevent stale stat info
 		local encrypted_files=$(git ls-crypt)
@@ -538,13 +531,13 @@ export_gpg() {
 		die 1 'GPG recipient key "%s" does not exist' "$gpg_recipient"
 	fi
 
-	local current_cipher=$(git config --get --local ${CONFIG_TRANSCRYPT_CIPHER})
-	local current_password=$(git config --get --local ${CONFIG_TRANSCRYPT_PASSWORD})
-	mkdir -p "${GIT_DIR}/${CONFIG_CRYPT}"
+	local current_cipher=$(git config --get --local transcrypt.cipher)
+	local current_password=$(git config --get --local transcrypt.password)
+	mkdir -p "${GIT_DIR}/crypt"
 
 	local gpg_encrypt_cmd="gpg --batch --recipient $gpg_recipient --trust-model always --yes --armor --quiet --encrypt -"
-	printf 'password=%s\ncipher=%s\n' "$current_password" "$current_cipher" | $gpg_encrypt_cmd > "${GIT_DIR}/${CONFIG_CRYPT}/${gpg_recipient}.asc"
-	printf "The transcrypt configuration has been encrypted and exported to:\n%s/${CONFIG_CRYPT}/%s.asc\n" "$GIT_DIR" "$gpg_recipient"
+	printf 'password=%s\ncipher=%s\n' "$current_password" "$current_cipher" | $gpg_encrypt_cmd >"${GIT_DIR}/crypt/${gpg_recipient}.asc"
+	printf "The transcrypt configuration has been encrypted and exported to:\n%s/crypt/%s.asc\n" "$GIT_DIR" "$gpg_recipient"
 }
 
 # import password and cipher from a gpg encrypted file
@@ -553,10 +546,10 @@ import_gpg() {
 	command -v gpg >/dev/null || die 'required command "gpg" was not found'
 
 	local path
-	if [[ -f "${GIT_DIR}/${CONFIG_CRYPT}/${gpg_import_file}" ]]; then
-		path="${GIT_DIR}/${CONFIG_CRYPT}/${gpg_import_file}"
-	elif [[ -f "${GIT_DIR}/${CONFIG_CRYPT}/${gpg_import_file}.asc" ]]; then
-		path="${GIT_DIR}/${CONFIG_CRYPT}/${gpg_import_file}.asc"
+	if [[ -f "${GIT_DIR}/crypt/${gpg_import_file}" ]]; then
+		path="${GIT_DIR}/crypt/${gpg_import_file}"
+	elif [[ -f "${GIT_DIR}/crypt/${gpg_import_file}.asc" ]]; then
+		path="${GIT_DIR}/crypt/${gpg_import_file}.asc"
 	elif [[ ! -f $gpg_import_file ]]; then
 		die 1 'the file "%s" does not exist' "$gpg_import_file"
 	else

--- a/transcrypt
+++ b/transcrypt
@@ -302,13 +302,6 @@ save_helper_scripts() {
 		#!/usr/bin/env bash
 		filename=$1
 
-		# Look up file's context name from .gitattributes, fall back to no context
-		context_config_group=""
-		context_name=$(git -c core.quotePath=false check-attr crypt-context -- "$filename" | awk 'BEGIN { FS = ": " }; { print $3 }')
-		if [[ ! "$context_name" = 'unspecified' ]]; then
-		  context_config_group="$context_name."
-		fi
-
 		# ignore empty files
 		if [[ -s $filename ]]; then
 		  # cache STDIN to test if it's already encrypted
@@ -320,6 +313,13 @@ save_helper_scripts() {
 		  if [[ $firstbytes == "U2FsdGVk" ]]; then
 		    cat "$tempfile"
 		  else
+		    # Look up file's context name from .gitattributes, fall back to no context
+		    context_config_group=""
+		    context_name=$(git -c core.quotePath=false check-attr crypt-context -- "$filename" | awk 'BEGIN { FS = ": " }; { print $3 }')
+		    if [[ ! "$context_name" = 'unspecified' ]]; then
+		      context_config_group="$context_name."
+		    fi
+
 		    cipher=$(git config --get --local transcrypt.${context_config_group}cipher)
 		    password=$(git config --get --local transcrypt.${context_config_group}password)
 		    salt=$(openssl dgst -hmac "${filename}:${password}" -sha256 "$filename" | tr -d '\r\n' | tail -c 16)
@@ -350,15 +350,15 @@ save_helper_scripts() {
 		#!/usr/bin/env bash
 		filename=$1
 
-		# Look up file's context name from .gitattributes, fall back to no context
-		context_config_group=""
-		context_name=$(git -c core.quotePath=false check-attr crypt-context -- "$filename" | awk 'BEGIN { FS = ": " }; { print $3 }')
-		if [[ ! "$context_name" = 'unspecified' ]]; then
-		  context_config_group="$context_name."
-		fi
-
 		# ignore empty files
 		if [[ -s $filename ]]; then
+		  # Look up file's context name from .gitattributes, fall back to no context
+		  context_config_group=""
+		  context_name=$(git -c core.quotePath=false check-attr crypt-context -- "$filename" | awk 'BEGIN { FS = ": " }; { print $3 }')
+		  if [[ ! "$context_name" = 'unspecified' ]]; then
+		    context_config_group="$context_name."
+		  fi
+
 		  cipher=$(git config --get --local transcrypt.${context_config_group}cipher)
 		  password=$(git config --get --local transcrypt.${context_config_group}password)
 		  ENC_PASS=$password openssl enc -$cipher -md MD5 -pass env:ENC_PASS -d -a -in "$filename" 2>/dev/null || cat "$filename"

--- a/transcrypt
+++ b/transcrypt
@@ -13,6 +13,13 @@ set -euo pipefail
 # that can be be found in the LICENSE file.
 #
 
+##### Multi-context support via optional 'CONTEXT' envvar
+
+CONFIG_TRANSCRYPT_VERSION=transcrypt.version${CONTEXT:-}
+CONFIG_TRANSCRYPT_CIPHER=transcrypt.cipher${CONTEXT:-}
+CONFIG_TRANSCRYPT_PASSWORD=transcrypt.password${CONTEXT:-}
+CONFIG_CRYPT=crypt${CONTEXT:-}
+
 ##### CONSTANTS
 
 # the release version of this script
@@ -27,7 +34,7 @@ readonly YES_REGEX='^[Yy]$'
 ## Repository Metadata
 
 # whether or not transcrypt is already configured
-readonly CONFIGURED=$(git config --get --local transcrypt.version 2>/dev/null)
+readonly CONFIGURED=$(git config --get --local $CONFIG_TRANSCRYPT_VERSION 2>/dev/null)
 
 # the current git repository's top-level directory
 readonly REPO=$(git rev-parse --show-toplevel 2>/dev/null)
@@ -265,7 +272,7 @@ stage_rekeyed_files() {
 
 # save helper scripts under the repository's git directory
 save_helper_scripts() {
-	mkdir -p "${GIT_DIR}/crypt"
+	mkdir -p "${GIT_DIR}/${CONFIG_CRYPT}"
 
 	# The `decryption -> encryption` process on an unchanged file must be
 	# deterministic for everything to work transparently. To do that, the same
@@ -274,51 +281,51 @@ save_helper_scripts() {
 	# (keyed with a combination of the filename and transcrypt password), and
 	# then use the last 16 bytes of that HMAC for the file's unique salt.
 
-	cat <<-'EOF' >"${GIT_DIR}/crypt/clean"
+	cat <<-EOF > "${GIT_DIR}/${CONFIG_CRYPT}/clean"
 		#!/usr/bin/env bash
-		filename=$1
+		filename=\$1
 		# ignore empty files
-		if [[ -s $filename ]]; then
+		if [[ -s \$filename ]]; then
 		  # cache STDIN to test if it's already encrypted
-		  tempfile=$(mktemp 2>/dev/null || mktemp -t tmp)
-		  trap 'rm -f "$tempfile"' EXIT
-		  tee "$tempfile" &>/dev/null
+		  tempfile=\$(mktemp 2>/dev/null || mktemp -t tmp)
+		  trap 'rm -f "\$tempfile"' EXIT
+		  tee "\$tempfile" &>/dev/null
 		  # the first bytes of an encrypted file are always "Salted" in Base64
-		  read -n 8 firstbytes <"$tempfile"
-		  if [[ $firstbytes == "U2FsdGVk" ]]; then
-		    cat "$tempfile"
+		  read -n 8 firstbytes < "\$tempfile"
+		  if [[ \$firstbytes == "U2FsdGVk" ]]; then
+		    cat "\$tempfile"
 		  else
-		    cipher=$(git config --get --local transcrypt.cipher)
-		    password=$(git config --get --local transcrypt.password)
-		    salt=$(openssl dgst -hmac "${filename}:${password}" -sha256 "$filename" | tr -d '\r\n' | tail -c 16)
-		    ENC_PASS=$password openssl enc -$cipher -md MD5 -pass env:ENC_PASS -e -a -S "$salt" -in "$tempfile"
+		    cipher=\$(git config --get --local ${CONFIG_TRANSCRYPT_CIPHER})
+		    password=\$(git config --get --local ${CONFIG_TRANSCRYPT_PASSWORD})
+		    salt=\$(openssl dgst -hmac "\${filename}:\${password}" -sha256 "\$filename" | tail -c 16)
+		    ENC_PASS=\$password openssl enc -\$cipher -md MD5 -pass env:ENC_PASS -e -a -S "\$salt" -in "\$tempfile"
 		  fi
 		fi
 	EOF
 
-	cat <<-'EOF' >"${GIT_DIR}/crypt/smudge"
+	cat <<-EOF > "${GIT_DIR}/${CONFIG_CRYPT}/smudge"
 		#!/usr/bin/env bash
-		tempfile=$(mktemp 2>/dev/null || mktemp -t tmp)
-		trap 'rm -f "$tempfile"' EXIT
-		cipher=$(git config --get --local transcrypt.cipher)
-		password=$(git config --get --local transcrypt.password)
-		tee "$tempfile" | ENC_PASS=$password openssl enc -$cipher -md MD5 -pass env:ENC_PASS -d -a 2>/dev/null || cat "$tempfile"
+		tempfile=\$(mktemp 2>/dev/null || mktemp -t tmp)
+		trap 'rm -f "\$tempfile"' EXIT
+		cipher=\$(git config --get --local ${CONFIG_TRANSCRYPT_CIPHER})
+		password=\$(git config --get --local ${CONFIG_TRANSCRYPT_PASSWORD})
+		tee "\$tempfile" | ENC_PASS=\$password openssl enc -\$cipher -md MD5 -pass env:ENC_PASS -d -a 2>/dev/null || cat "\$tempfile"
 	EOF
 
-	cat <<-'EOF' >"${GIT_DIR}/crypt/textconv"
+	cat <<-EOF > "${GIT_DIR}/${CONFIG_CRYPT}/textconv"
 		#!/usr/bin/env bash
-		filename=$1
+		filename=\$1
 		# ignore empty files
-		if [[ -s $filename ]]; then
-		  cipher=$(git config --get --local transcrypt.cipher)
-		  password=$(git config --get --local transcrypt.password)
-		  ENC_PASS=$password openssl enc -$cipher -md MD5 -pass env:ENC_PASS -d -a -in "$filename" 2>/dev/null || cat "$filename"
+		if [[ -s \$filename ]]; then
+		  cipher=\$(git config --get --local ${CONFIG_TRANSCRYPT_CIPHER})
+		  password=\$(git config --get --local ${CONFIG_TRANSCRYPT_PASSWORD})
+		  ENC_PASS=\$password openssl enc -\$cipher -md MD5 -pass env:ENC_PASS -d -a -in "\$filename" 2>/dev/null || cat "\$filename"
 		fi
 	EOF
 
 	# make scripts executable
 	for script in {clean,smudge,textconv}; do
-		chmod 0755 "${GIT_DIR}/crypt/${script}"
+		chmod 0755 "${GIT_DIR}/${CONFIG_CRYPT}/${script}"
 	done
 }
 
@@ -327,35 +334,35 @@ save_configuration() {
 	save_helper_scripts
 
 	# write the encryption info
-	git config transcrypt.version "$VERSION"
-	git config transcrypt.cipher "$cipher"
-	git config transcrypt.password "$password"
+	git config $CONFIG_TRANSCRYPT_VERSION "$VERSION"
+	git config ${CONFIG_TRANSCRYPT_CIPHER} "$cipher"
+	git config ${CONFIG_TRANSCRYPT_PASSWORD} "$password"
 
 	# write the filter settings
 	if [[ -d $(git rev-parse --git-common-dir) ]]; then
 		# this allows us to support multiple working trees via git-worktree
 		# ...but the --git-common-dir flag was only added in November 2014
-		git config filter.crypt.clean '"$(git rev-parse --git-common-dir)"/crypt/clean %f'
-		git config filter.crypt.smudge '"$(git rev-parse --git-common-dir)"/crypt/smudge'
-		git config diff.crypt.textconv '"$(git rev-parse --git-common-dir)"/crypt/textconv'
+		git config filter.${CONFIG_CRYPT}.clean '"$(git rev-parse --git-common-dir)"'/${CONFIG_CRYPT}'/clean %f'
+		git config filter.${CONFIG_CRYPT}.smudge '"$(git rev-parse --git-common-dir)"'/${CONFIG_CRYPT}/smudge
+		git config diff.${CONFIG_CRYPT}.textconv '"$(git rev-parse --git-common-dir)"'/${CONFIG_CRYPT}/textconv
 	else
-		git config filter.crypt.clean '"$(git rev-parse --git-dir)"/crypt/clean %f'
-		git config filter.crypt.smudge '"$(git rev-parse --git-dir)"/crypt/smudge'
-		git config diff.crypt.textconv '"$(git rev-parse --git-dir)"/crypt/textconv'
+		git config filter.${CONFIG_CRYPT}.clean '"$(git rev-parse --git-dir)"'/${CONFIG_CRYPT}/clean %f
+		git config filter.${CONFIG_CRYPT}.smudge '"$(git rev-parse --git-dir)"'/${CONFIG_CRYPT}/smudge
+		git config diff.${CONFIG_CRYPT}.textconv '"$(git rev-parse --git-dir)"'/${CONFIG_CRYPT}/textconv
 	fi
-	git config filter.crypt.required 'true'
-	git config diff.crypt.cachetextconv 'true'
-	git config diff.crypt.binary 'true'
+	git config filter.${CONFIG_CRYPT}.required 'true'
+	git config diff.${CONFIG_CRYPT}.cachetextconv 'true'
+	git config diff.${CONFIG_CRYPT}.binary 'true'
 	git config merge.renormalize 'true'
 
 	# add a git alias for listing encrypted files
-	git config alias.ls-crypt "!git ls-files | git check-attr --stdin filter | awk 'BEGIN { FS = \":\" }; /crypt$/{ print \$1 }'"
+	git config alias.ls-crypt "!git ls-files | git check-attr --stdin filter | awk 'BEGIN { FS = \":\" }; /crypt(-[a-zA-Z]+)?$/{ print \$1 }'"
 }
 
 # display the current configuration settings
 display_configuration() {
-	local current_cipher=$(git config --get --local transcrypt.cipher)
-	local current_password=$(git config --get --local transcrypt.password)
+	local current_cipher=$(git config --get --local ${CONFIG_TRANSCRYPT_CIPHER})
+	local current_password=$(git config --get --local ${CONFIG_TRANSCRYPT_PASSWORD})
 	local escaped_password=${current_password//\'/\'\\\'\'}
 
 	printf 'The current repository was configured using transcrypt version %s\n' "$CONFIGURED"
@@ -372,8 +379,8 @@ display_configuration() {
 # remove transcrypt-related settings from the repository's git config
 clean_gitconfig() {
 	git config --remove-section transcrypt 2>/dev/null || true
-	git config --remove-section filter.crypt 2>/dev/null || true
-	git config --remove-section diff.crypt 2>/dev/null || true
+	git config --remove-section filter.${CONFIG_CRYPT} 2>/dev/null || true
+	git config --remove-section diff.${CONFIG_CRYPT} 2>/dev/null || true
 	git config --unset merge.renormalize
 
 	# remove the merge section if it's now empty
@@ -452,9 +459,9 @@ uninstall_transcrypt() {
 
 		# remove helper scripts
 		for script in {clean,smudge,textconv}; do
-			[[ ! -f "${GIT_DIR}/crypt/${script}" ]] || rm "${GIT_DIR}/crypt/${script}"
+			[[ ! -f "${GIT_DIR}/${CONFIG_CRYPT}/${script}" ]] || rm "${GIT_DIR}/${CONFIG_CRYPT}/${script}"
 		done
-		[[ ! -d "${GIT_DIR}/crypt" ]] || rmdir "${GIT_DIR}/crypt"
+		[[ ! -d "${GIT_DIR}/${CONFIG_CRYPT}" ]] || rmdir "${GIT_DIR}/${CONFIG_CRYPT}"
 
 		# touch all encrypted files to prevent stale stat info
 		local encrypted_files=$(git ls-crypt)
@@ -531,13 +538,13 @@ export_gpg() {
 		die 1 'GPG recipient key "%s" does not exist' "$gpg_recipient"
 	fi
 
-	local current_cipher=$(git config --get --local transcrypt.cipher)
-	local current_password=$(git config --get --local transcrypt.password)
-	mkdir -p "${GIT_DIR}/crypt"
+	local current_cipher=$(git config --get --local ${CONFIG_TRANSCRYPT_CIPHER})
+	local current_password=$(git config --get --local ${CONFIG_TRANSCRYPT_PASSWORD})
+	mkdir -p "${GIT_DIR}/${CONFIG_CRYPT}"
 
 	local gpg_encrypt_cmd="gpg --batch --recipient $gpg_recipient --trust-model always --yes --armor --quiet --encrypt -"
-	printf 'password=%s\ncipher=%s\n' "$current_password" "$current_cipher" | $gpg_encrypt_cmd >"${GIT_DIR}/crypt/${gpg_recipient}.asc"
-	printf "The transcrypt configuration has been encrypted and exported to:\n%s/crypt/%s.asc\n" "$GIT_DIR" "$gpg_recipient"
+	printf 'password=%s\ncipher=%s\n' "$current_password" "$current_cipher" | $gpg_encrypt_cmd > "${GIT_DIR}/${CONFIG_CRYPT}/${gpg_recipient}.asc"
+	printf "The transcrypt configuration has been encrypted and exported to:\n%s/${CONFIG_CRYPT}/%s.asc\n" "$GIT_DIR" "$gpg_recipient"
 }
 
 # import password and cipher from a gpg encrypted file
@@ -546,10 +553,10 @@ import_gpg() {
 	command -v gpg >/dev/null || die 'required command "gpg" was not found'
 
 	local path
-	if [[ -f "${GIT_DIR}/crypt/${gpg_import_file}" ]]; then
-		path="${GIT_DIR}/crypt/${gpg_import_file}"
-	elif [[ -f "${GIT_DIR}/crypt/${gpg_import_file}.asc" ]]; then
-		path="${GIT_DIR}/crypt/${gpg_import_file}.asc"
+	if [[ -f "${GIT_DIR}/${CONFIG_CRYPT}/${gpg_import_file}" ]]; then
+		path="${GIT_DIR}/${CONFIG_CRYPT}/${gpg_import_file}"
+	elif [[ -f "${GIT_DIR}/${CONFIG_CRYPT}/${gpg_import_file}.asc" ]]; then
+		path="${GIT_DIR}/${CONFIG_CRYPT}/${gpg_import_file}.asc"
 	elif [[ ! -f $gpg_import_file ]]; then
 		die 1 'the file "%s" does not exist' "$gpg_import_file"
 	else

--- a/transcrypt
+++ b/transcrypt
@@ -59,9 +59,6 @@ gather_repo_metadata() {
 	# whether or not transcrypt is already configured
 	readonly INSTALLED_VERSION=$(git config --get --local transcrypt.version 2>/dev/null)
 
-	# fetch list of context names already configured
-	readonly CONFIGURED_CONTEXTS=$(get_contexts_from_git_config)
-
 	# the current git repository's top-level directory
 	readonly REPO=$(git rev-parse --show-toplevel 2>/dev/null)
 
@@ -89,6 +86,10 @@ gather_repo_metadata() {
 	else
 		readonly GIT_ATTRIBUTES="${REPO}/.gitattributes"
 	fi
+
+	# fetch list of context names already configured or in .gitattributes
+	readonly CONFIGURED_CONTEXTS=$(get_contexts_from_git_config)
+	readonly GITATTRIBUTES_CONTEXTS=$(get_contexts_from_git_attributes)
 }
 
 # print a message to stderr
@@ -881,28 +882,30 @@ get_contexts_from_git_config() {
 
 # Echo space-delimited list of context names defined in the .gitattributes file
 get_contexts_from_git_attributes() {
-	if [[ ! -f $GIT_ATTRIBUTES ]]; then
-		echo ""
-	fi
-	# Capture contents of .gitattributes without comments (leading # hash)
-	attr_lines=$(sed '/^.*#/d' <"$GIT_ATTRIBUTES")
-	extract_context_name_regex="crypt-context=(${CONTEXT_REGEX})"
-	contexts=()
-	for attr_line in $attr_lines; do
-		if [[ $attr_line =~ $extract_context_name_regex ]]; then
-			contexts+=("${BASH_REMATCH[1]}")
-		elif [[ $attr_line =~ 'filter=crypt' ]]; then
-			contexts+=('default')
+	if [[ -f $GIT_ATTRIBUTES ]]; then
+		# Capture contents of .gitattributes without comments (leading # hash)
+		attr_lines=$(sed '/^.*#/d' <"$GIT_ATTRIBUTES")
+		extract_context_name_regex="crypt-context=(${CONTEXT_REGEX})"
+		recognise_crypt_regex="filter=crypt"
+		contexts=()
+		IFS=$'\n'
+		for attr_line in ${attr_lines}; do
+			if [[ $attr_line =~ $extract_context_name_regex ]]; then
+				contexts+=("${BASH_REMATCH[1]}")
+			elif [[ $attr_line =~ $recognise_crypt_regex ]]; then
+				contexts+=('default')
+			fi
+		done
+		unset IFS
+		if [ "${contexts:-}" ]; then
+			trim "$(printf "%q " "${contexts[@]}")"
 		fi
-	done
-	if [ "${contexts:-}" ]; then
-		trim "$(printf "%q " "${contexts[@]}")"
 	fi
 }
 
 # Echo all context names, sorted and distinct, from the git config or .gitattributes
 get_contexts() {
-	combined_contexts="$CONFIGURED_CONTEXTS $(get_contexts_from_git_attributes)"
+	combined_contexts="$CONFIGURED_CONTEXTS $GITATTRIBUTES_CONTEXTS"
 	sorted_contexts=$(echo "$combined_contexts" | tr ' ' '\n' | sort -u | tr '\n' ' ')
 	if [ "${sorted_contexts:-}" ]; then
 		trim "$sorted_contexts"
@@ -941,12 +944,11 @@ trim() {
 }
 
 list_contexts() {
-	contexts_in_git_attributes=$(get_contexts_from_git_attributes)
 	for context in $(get_contexts); do
 		# shellcheck disable=SC2086
 		if ! is_item_in_array "$context" ${CONFIGURED_CONTEXTS}; then
 			echo "$context (not initialised)"
-		elif ! is_item_in_array "$context" ${contexts_in_git_attributes}; then
+		elif ! is_item_in_array "$context" ${GITATTRIBUTES_CONTEXTS}; then
 			echo "$context (no patterns in .gitattributes)"
 		else
 			echo "$context"
@@ -1146,6 +1148,7 @@ while [[ "${1:-}" != '' ]]; do
 	--list-contexts)
 		list_ctxs='true'
 		ignore_config_status='true'
+		requires_clean_repo=''
 		;;
 	-c | --cipher)
 		cipher=$2

--- a/transcrypt
+++ b/transcrypt
@@ -57,7 +57,7 @@ realpath() {
 # establish repository metadata and directory handling
 gather_repo_metadata() {
 	# whether or not transcrypt is already configured
-	readonly CONFIGURED=$(git config --get --local $CONTEXT_TRANSCRYPT_VERSION 2>/dev/null)
+	readonly CONFIGURED=$(git config --get --local "$CONTEXT_TRANSCRYPT_VERSION" 2>/dev/null)
 
 	# the current git repository's top-level directory
 	readonly REPO=$(git rev-parse --show-toplevel 2>/dev/null)
@@ -471,31 +471,31 @@ save_configuration() {
 		# this allows us to support multiple working trees via git-worktree
 		# ...but the --git-common-dir flag was only added in November 2014
 		# shellcheck disable=SC2016
-		git config filter.${CONTEXT_CRYPT}.clean '"$(git rev-parse --git-common-dir)"/crypt/clean '$CONTEXT' %f'
+		git config filter."${CONTEXT_CRYPT}".clean '"$(git rev-parse --git-common-dir)"/crypt/clean '"$CONTEXT"' %f'
 		# shellcheck disable=SC2016
-		git config filter.${CONTEXT_CRYPT}.smudge '"$(git rev-parse --git-common-dir)"/crypt/smudge '$CONTEXT
+		git config filter."${CONTEXT_CRYPT}".smudge '"$(git rev-parse --git-common-dir)"/crypt/smudge '"$CONTEXT"
 		# shellcheck disable=SC2016
-		git config diff.${CONTEXT_CRYPT}.textconv '"$(git rev-parse --git-common-dir)"/crypt/textconv '$CONTEXT
+		git config diff."${CONTEXT_CRYPT}".textconv '"$(git rev-parse --git-common-dir)"/crypt/textconv '"$CONTEXT"
 		# shellcheck disable=SC2016
-		git config merge.${CONTEXT_CRYPT}.driver '"$(git rev-parse --git-common-dir)"/crypt/merge '$CONTEXT' %O %A %B %L %P'
+		git config merge."${CONTEXT_CRYPT}".driver '"$(git rev-parse --git-common-dir)"/crypt/merge '"$CONTEXT"' %O %A %B %L %P'
 	else
 		# shellcheck disable=SC2016
-		git config filter.${CONTEXT_CRYPT}.clean '"$(git rev-parse --git-dir)"/crypt/clean '$CONTEXT ' %f'
+		git config filter."${CONTEXT_CRYPT}".clean '"$(git rev-parse --git-dir)"/crypt/clean '"$CONTEXT" ' %f'
 		# shellcheck disable=SC2016
-		git config filter.${CONTEXT_CRYPT}.smudge '"$(git rev-parse --git-dir)"/crypt/smudge '$CONTEXT
+		git config filter."${CONTEXT_CRYPT}".smudge '"$(git rev-parse --git-dir)"/crypt/smudge '"$CONTEXT"
 		# shellcheck disable=SC2016
-		git config diff.${CONTEXT_CRYPT}.textconv '"$(git rev-parse --git-dir)"/crypt/textconv '$CONTEXT
+		git config diff."${CONTEXT_CRYPT}".textconv '"$(git rev-parse --git-dir)"/crypt/textconv '"$CONTEXT"
 		# shellcheck disable=SC2016
-		git config merge.${CONTEXT_CRYPT}.driver '"$(git rev-parse --git-dir)"/crypt/merge '$CONTEXT' %O %A %B %L %P'
+		git config merge."${CONTEXT_CRYPT}".driver '"$(git rev-parse --git-dir)"/crypt/merge '"$CONTEXT"' %O %A %B %L %P'
 	fi
-	git config filter.${CONTEXT_CRYPT}.required 'true'
-	git config diff.${CONTEXT_CRYPT}.cachetextconv 'true'
-	git config diff.${CONTEXT_CRYPT}.binary 'true'
+	git config filter."${CONTEXT_CRYPT}".required 'true'
+	git config diff."${CONTEXT_CRYPT}".cachetextconv 'true'
+	git config diff."${CONTEXT_CRYPT}".binary 'true'
 	git config merge.renormalize 'true'
-	git config merge.${CONTEXT_CRYPT}.name 'Merge transcrypt secret files'
+	git config merge."${CONTEXT_CRYPT}".name 'Merge transcrypt secret files'
 
 	# add a git alias for listing encrypted files in specific context, including 'default'
-	git config alias.${CONTEXT_LS_CRYPT} "!git ls-files | git check-attr --stdin filter | awk 'BEGIN { FS = \":\" }; / ${CONTEXT_CRYPT}$/{ print \$1 }'"
+	git config alias."${CONTEXT_LS_CRYPT}" "!git ls-files | git check-attr --stdin filter | awk 'BEGIN { FS = \":\" }; / ${CONTEXT_CRYPT}$/{ print \$1 }'"
 
 	# add git alias for listing ALL encrypted files regardless of context
 	git config alias.ls-crypt "!git -c core.quotePath=false ls-files | git -c core.quotePath=false check-attr --stdin filter | awk 'BEGIN { FS = \":\" }; / (${CONTEXT_REGEX}-)?crypt$/{ print \$1 }'"
@@ -504,16 +504,16 @@ save_configuration() {
 # display the current configuration settings
 display_configuration() {
 	local current_cipher
-	current_cipher=$(git config --get --local $CONTEXT_TRANSCRYPT_CIPHER)
+	current_cipher=$(git config --get --local "$CONTEXT_TRANSCRYPT_CIPHER")
 	local current_password
-	current_password=$(git config --get --local $CONTEXT_TRANSCRYPT_PASSWORD)
+	current_password=$(git config --get --local "$CONTEXT_TRANSCRYPT_PASSWORD")
 	local escaped_password=${current_password//\'/\'\\\'\'}
 
 	contexts=$(get_contexts)
-	contexts_array=($contexts)  # Convert list to bash array so we can count elements
+	contexts_array=("$contexts") # Convert list to bash array so we can count elements
 
 	printf 'The current repository was configured using transcrypt version %s\n' "$CONFIGURED"
-	printf "and has the following configuration$CONTEXT_DESC_SUFFIX:\n\n"
+	printf "and has the following configuration%s:\n\n" "$CONTEXT_DESC_SUFFIX"
 	[[ ! $REPO ]] || printf '  GIT_WORK_TREE:  %s\n' "$REPO"
 	printf '  GIT_DIR:        %s\n' "$GIT_DIR"
 	printf '  GIT_ATTRIBUTES: %s\n\n' "$GIT_ATTRIBUTES"
@@ -525,7 +525,7 @@ display_configuration() {
 	if [[ "${#contexts_array[@]}" -gt "1" ]]; then
 		printf 'The repository has %s contexts: %s\n\n' "${#contexts_array[@]}" "$contexts"
 	fi
-	printf "Copy and paste the following command to initialize a cloned repository$CONTEXT_DESC_SUFFIX:\n\n"
+	printf "Copy and paste the following command to initialize a cloned repository%s:\n\n" "$CONTEXT_DESC_SUFFIX"
 	if [[ $CONTEXT != 'default' ]]; then
 		printf "  transcrypt -C $CONTEXT -c %s -p '%s'\n" "$current_cipher" "$escaped_password"
 	else
@@ -582,7 +582,7 @@ force_checkout() {
 		# this would normally delete uncommitted changes in the working directory,
 		# but we already made sure the repo was clean during the safety checks
 		local encrypted_files
-		encrypted_files=$(git $CONTEXT_LS_CRYPT)
+		encrypted_files=$(git "$CONTEXT_LS_CRYPT")
 		cd "$REPO" || die 1 'could not change into the "%s" directory' "$REPO"
 		IFS=$'\n'
 		for file in $encrypted_files; do
@@ -683,7 +683,7 @@ uninstall_transcrypt() {
 		# remove the `git ls-crypt` global alias and each context-specific alias
 		git config --unset alias.ls-crypt
 		for context in $contexts_in_git_config; do
-			git config --unset alias.ls-${context}-crypt
+			git config --unset alias.ls-"${context}"-crypt
 		done
 
 		# remove the alias section if it's now empty
@@ -703,12 +703,12 @@ uninstall_transcrypt() {
 
 			case $OSTYPE in
 			darwin*)
-				/usr/bin/sed -i '' "/filter=$context_crypt diff=$context_crypt[ \t]*$/d" "$GIT_ATTRIBUTES"
-				/usr/bin/sed -i '' "/filter=$context_crypt diff=$context_crypt merge=$context_crypt[ \t]*$/d" "$GIT_ATTRIBUTES"
+				/usr/bin/sed -i '' "/filter=${context_crypt} diff=${context_crypt}[ \t]*$/d" "$GIT_ATTRIBUTES"
+				/usr/bin/sed -i '' "/filter=${context_crypt} diff=${context_crypt} merge=${context_crypt}[ \t]*$/d" "$GIT_ATTRIBUTES"
 				;;
 			linux*)
-				sed -i "/filter=$context_crypt diff=$context_crypt[ \t]*$/d" "$GIT_ATTRIBUTES"
-				sed -i "/filter=$context_crypt diff=$context_crypt merge=$context_crypt[ \t]*$/d" "$GIT_ATTRIBUTES"
+				sed -i "/filter=${context_crypt} diff=${context_crypt}[ \t]*$/d" "$GIT_ATTRIBUTES"
+				sed -i "/filter=${context_crypt} diff=${context_crypt} merge=${context_crypt}[ \t]*$/d" "$GIT_ATTRIBUTES"
 				;;
 			esac
 		done
@@ -755,7 +755,7 @@ upgrade_transcrypt() {
 	save_configuration
 
 	# Re-instate contents of .gitattributes
-	echo "$ORIG_GITATTRIBUTES" > "$GIT_ATTRIBUTES"
+	echo "$ORIG_GITATTRIBUTES" >"$GIT_ATTRIBUTES"
 
 	# Update .gitattributes for transcrypt'ed files to include "merge=crypt" config
 	case $OSTYPE in
@@ -821,9 +821,9 @@ export_gpg() {
 	fi
 
 	local current_cipher
-	current_cipher=$(git config --get --local $CONTEXT_TRANSCRYPT_CIPHER)
+	current_cipher=$(git config --get --local "$CONTEXT_TRANSCRYPT_CIPHER")
 	local current_password
-	current_password=$(git config --get --local $CONTEXT_TRANSCRYPT_PASSWORD)
+	current_password=$(git config --get --local "$CONTEXT_TRANSCRYPT_PASSWORD")
 	mkdir -p "${GIT_DIR}/crypt"
 
 	local gpg_encrypt_cmd="gpg --batch --recipient $gpg_recipient --trust-model always --yes --armor --quiet --encrypt -"
@@ -869,10 +869,10 @@ get_contexts_from_git_config() {
 	config_name=$(git config --local --name-only --list)
 	extract_context_name_regex="transcrypt.(${CONTEXT_REGEX})?-version"
 	for name in $config_name; do
-		if [[ $name =~ 'transcrypt.version' ]]; then
-			contexts+=' default'
+		if [[ $name =~ transcrypt\.version ]]; then
+			contexts+=('default')
 		elif [[ $name =~ $extract_context_name_regex ]]; then
-			contexts+=" ${BASH_REMATCH[1]}"
+			contexts+=("${BASH_REMATCH[1]}")
 		fi
 	done
 	# Avoid 'unbound variable' if array is empty: https://stackoverflow.com/a/7577209/4970
@@ -886,13 +886,13 @@ get_contexts_from_git_attributes() {
 	fi
 	contexts=()
 	# Capture contents of .gitattributes without comments (leading # hash)
-	attrs=$(cat $GIT_ATTRIBUTES | sed '/^.*#/d')
+	attrs=$(sed '/^.*#/d' <"$GIT_ATTRIBUTES")
 	extract_context_name_regex="filter=(${CONTEXT_REGEX})?-crypt"
 	for attr in $attrs; do
 		if [[ $attr =~ 'filter=crypt' ]]; then
-			contexts+=' default'
+			contexts+=('default')
 		elif [[ $attr =~ $extract_context_name_regex ]]; then
-			contexts+=" ${BASH_REMATCH[1]}"
+			contexts+=("${BASH_REMATCH[1]}")
 		fi
 	done
 	# Avoid 'unbound variable' if array is empty: https://stackoverflow.com/a/7577209/4970
@@ -902,7 +902,7 @@ get_contexts_from_git_attributes() {
 # Echo all context names, sorted and distinct, as defined in the git config or .gitattributes file
 get_contexts() {
 	combined_contexts="$(get_contexts_from_git_config) $(get_contexts_from_git_attributes)"
-	sorted_contexts=$(printf '%s\n' $combined_contexts | sort -u | tr '\n' ' ')
+	sorted_contexts=$(printf '%s\n' "$combined_contexts" | sort -u | tr '\n' ' ')
 	# Avoid 'unbound variable' if array is empty: https://stackoverflow.com/a/7577209/4970
 	echo ${sorted_contexts[@]+"${sorted_contexts[@]}"}
 }
@@ -910,7 +910,7 @@ get_contexts() {
 # Utility function returns a truthy value if value $1 is in bash array $2
 is_item_in_array() {
 	# Based on https://stackoverflow.com/a/47541882/4970
-	return $(printf '%s\n' $2 | grep -q "^${1}$")
+	return "$(printf '%s\n' "$2" | grep -q "^${1}$")"
 }
 
 list_contexts() {
@@ -918,11 +918,11 @@ list_contexts() {
 	in_git_attributes=$(get_contexts_from_git_attributes)
 	for context in $(get_contexts); do
 		config_status='not configured'
-		if is_item_in_array $context "${in_git_config[@]}"; then
+		if is_item_in_array "$context" "${in_git_config[@]}"; then
 			config_status='configured'
 		fi
 		attr_status='not in .gitattributes'
-		if is_item_in_array $context "${in_git_attributes[@]}"; then
+		if is_item_in_array "$context" "${in_git_attributes[@]}"; then
 			attr_status='in .gitattributes'
 		fi
 		echo "$context ($config_status, $attr_status)"

--- a/transcrypt
+++ b/transcrypt
@@ -117,8 +117,8 @@ run_safety_checks() {
 	full_context_regex="^${CONTEXT_REGEX}$"
 	if [[ ! $CONTEXT =~ $full_context_regex ]]; then
 		warn "context name '${CONTEXT}' is invalid"
-		echo "Must be lowercase ASCII starting with a letter then zero or more letters or numbers, hyphen seperator permitted"
-		echo "Examples: x  prod  shh  admins-only  top-secret  abc-123-xyz"
+		echo "Must be lowercase ASCII, start with a letter, then zero or more letters or numbers. A hyphen (-) seperator is allowed"
+		echo "Examples: admin  admins-only  super-user  staging  production  top-secret  abc-123-xyz"
 		exit 1
 	fi
 

--- a/transcrypt
+++ b/transcrypt
@@ -445,7 +445,9 @@ save_helper_hooks() {
 
 	# Activate hook by copying it to the pre-commit script name, if safe to do so
 	pre_commit_hook="${RELATIVE_GIT_DIR}/hooks/pre-commit"
-	if [[ -f "$pre_commit_hook" ]]; then
+	if [[ -f "$pre_commit_hook" && "$CONTEXT" != "default" ]]; then
+		: # no-op, skip re-install of pre-commit hook for additional contexts
+	elif [[ -f "$pre_commit_hook" ]]; then
 		printf 'WARNING:\n' >&2
 		printf 'Cannot install Git pre-commit hook script because file already exists: %s\n' "$pre_commit_hook" >&2
 		printf 'Please manually install the pre-commit script saved as: %s\n' "$pre_commit_hook_installed" >&2
@@ -495,7 +497,7 @@ save_configuration() {
 	git config merge."${CONTEXT_CRYPT}".name 'Merge transcrypt secret files'
 
 	# add a git alias for listing encrypted files in specific context, including 'default'
-	git config alias."${CONTEXT_LS_CRYPT}" "!git ls-files | git check-attr --stdin filter | awk 'BEGIN { FS = \":\" }; / ${CONTEXT_CRYPT}$/{ print \$1 }'"
+	git config alias."${CONTEXT_LS_CRYPT}" "!git -c core.quotePath=false ls-files | git -c core.quotePath=false check-attr --stdin filter | awk 'BEGIN { FS = \":\" }; / ${CONTEXT_CRYPT}$/{ print \$1 }'"
 
 	# add git alias for listing ALL encrypted files regardless of context
 	git config alias.ls-crypt "!git -c core.quotePath=false ls-files | git -c core.quotePath=false check-attr --stdin filter | awk 'BEGIN { FS = \":\" }; / (${CONTEXT_REGEX}-)?crypt$/{ print \$1 }'"
@@ -866,17 +868,16 @@ import_gpg() {
 # Echo array of context names as defined in the git config
 get_contexts_from_git_config() {
 	contexts=()
-	config_name=$(git config --local --name-only --list)
-	extract_context_name_regex="transcrypt.(${CONTEXT_REGEX})?-version"
-	for name in $config_name; do
+	config_names=$(git config --local --name-only --list)
+	extract_context_name_regex="transcrypt\.(${CONTEXT_REGEX})-version"
+	for name in $config_names; do
 		if [[ $name =~ transcrypt\.version ]]; then
 			contexts+=('default')
 		elif [[ $name =~ $extract_context_name_regex ]]; then
-			contexts+=("${BASH_REMATCH[1]}")
+			contexts+=(${BASH_REMATCH[1]})
 		fi
 	done
-	# Avoid 'unbound variable' if array is empty: https://stackoverflow.com/a/7577209/4970
-	echo ${contexts[@]+"${contexts[@]}"}
+	printf "%q " "${contexts[@]:-}"
 }
 
 # Echo array of context names as defined in the .gitattributes file
@@ -887,30 +888,32 @@ get_contexts_from_git_attributes() {
 	contexts=()
 	# Capture contents of .gitattributes without comments (leading # hash)
 	attrs=$(sed '/^.*#/d' <"$GIT_ATTRIBUTES")
-	extract_context_name_regex="filter=(${CONTEXT_REGEX})?-crypt"
+	extract_context_name_regex="filter=(${CONTEXT_REGEX})-crypt"
 	for attr in $attrs; do
 		if [[ $attr =~ 'filter=crypt' ]]; then
 			contexts+=('default')
 		elif [[ $attr =~ $extract_context_name_regex ]]; then
-			contexts+=("${BASH_REMATCH[1]}")
+			contexts+=(${BASH_REMATCH[1]})
 		fi
 	done
-	# Avoid 'unbound variable' if array is empty: https://stackoverflow.com/a/7577209/4970
-	echo ${contexts[@]+"${contexts[@]}"}
+	printf "%q " "${contexts[@]:-}"
 }
 
 # Echo all context names, sorted and distinct, as defined in the git config or .gitattributes file
 get_contexts() {
 	combined_contexts="$(get_contexts_from_git_config) $(get_contexts_from_git_attributes)"
-	sorted_contexts=$(printf '%s\n' "$combined_contexts" | sort -u | tr '\n' ' ')
+	sorted_contexts=$(echo "$combined_contexts" | tr ' ' '\n' | sort -u | tr '\n' ' ')
 	# Avoid 'unbound variable' if array is empty: https://stackoverflow.com/a/7577209/4970
 	echo ${sorted_contexts[@]+"${sorted_contexts[@]}"}
 }
 
 # Utility function returns a truthy value if value $1 is in bash array $2
+# Based on https://stackoverflow.com/a/8574392/4970
 is_item_in_array() {
-	# Based on https://stackoverflow.com/a/47541882/4970
-	return "$(printf '%s\n' "$2" | grep -q "^${1}$")"
+  local e match="$1"
+  shift
+  for e; do [[ "$e" == "$match" ]] && return 0; done
+  return 1
 }
 
 list_contexts() {
@@ -918,11 +921,11 @@ list_contexts() {
 	in_git_attributes=$(get_contexts_from_git_attributes)
 	for context in $(get_contexts); do
 		config_status='not configured'
-		if is_item_in_array "$context" "${in_git_config[@]}"; then
+		if is_item_in_array "$context" ${in_git_config[@]}; then
 			config_status='configured'
 		fi
 		attr_status='not in .gitattributes'
-		if is_item_in_array "$context" "${in_git_attributes[@]}"; then
+		if is_item_in_array "$context" ${in_git_attributes[@]}; then
 			attr_status='in .gitattributes'
 		fi
 		echo "$context ($config_status, $attr_status)"
@@ -1060,7 +1063,7 @@ help() {
 		         $ transcrypt --context=ts
 
 		         # Use context name as a prefix to 'crypt' in .gitattributes
-		         $ echo 'ts_file  filter=ts-crypt diff=ts-crypt' >> .gitattributes
+		         $ echo 'ts_file  filter=ts-crypt diff=ts-crypt merge=ts-crypt' >> .gitattributes
 		         $ git add .gitattributes ts_file
 		         $ git commit -m 'Add encrypted version of a top-secret file'
 
@@ -1083,6 +1086,7 @@ help() {
 context=''
 cipher=''
 display_config=''
+list_ctxs=''
 flush_creds=''
 gpg_import_file=''
 gpg_recipient=''
@@ -1110,8 +1114,8 @@ while [[ "${1:-}" != '' ]]; do
 		context=${1#*=}
 		;;
 	--list-contexts)
-		list_contexts
-		exit 0
+		list_ctxs='true'
+		ignore_config_status='true'
 		;;
 	-c | --cipher)
 		cipher=$2
@@ -1215,10 +1219,10 @@ done
 if [[ $context ]]; then
 	readonly CONTEXT=$context
 	readonly CONTEXT_DESC_SUFFIX=" for context '$CONTEXT'"
-	readonly CONTEXT_TRANSCRYPT_VERSION=transcrypt.${CONTEXT_PREFIX}-version
-	readonly CONTEXT_TRANSCRYPT_CIPHER=transcrypt.${CONTEXT_PREFIX}-cipher
-	readonly CONTEXT_TRANSCRYPT_PASSWORD=transcrypt.${CONTEXT_PREFIX}-password
-	readonly CONTEXT_CRYPT=${CONTEXT_PREFIX}-crypt
+	readonly CONTEXT_TRANSCRYPT_VERSION=transcrypt.${CONTEXT}-version
+	readonly CONTEXT_TRANSCRYPT_CIPHER=transcrypt.${CONTEXT}-cipher
+	readonly CONTEXT_TRANSCRYPT_PASSWORD=transcrypt.${CONTEXT}-password
+	readonly CONTEXT_CRYPT=${CONTEXT}-crypt
 	# For ls-crypt aliases we want one for each context, including 'default'
 	readonly CONTEXT_LS_CRYPT="ls-$CONTEXT-crypt"
 else
@@ -1259,6 +1263,9 @@ elif [[ $display_config ]] && [[ $flush_creds ]]; then
 elif [[ $display_config ]]; then
 	display_configuration
 	exit 0
+elif [[ $list_ctxs ]]; then
+	list_contexts
+	exit 0
 elif [[ $flush_creds ]]; then
 	flush_credentials
 	exit 0
@@ -1295,6 +1302,6 @@ if [[ ! -f $GIT_ATTRIBUTES ]]; then
 	printf '#pattern  filter=crypt diff=crypt merge=crypt\n' >"$GIT_ATTRIBUTES"
 fi
 
-printf 'The repository has been successfully configured by transcrypt.\n'
+printf 'The repository has been successfully configured by transcrypt%s.\n' "$CONTEXT_DESC_SUFFIX"
 
 exit 0

--- a/transcrypt
+++ b/transcrypt
@@ -574,7 +574,7 @@ uninstall_transcrypt() {
 list_files() {
 	if [[ $IS_BARE == 'false' ]]; then
 		cd "$REPO" || die 1 'could not change into the "%s" directory' "$REPO"
-		git ls-files | git check-attr --stdin filter | awk 'BEGIN { FS = ":" }; /crypt$/{ print $1 }'
+		git ls-crypt-all
 	fi
 }
 

--- a/transcrypt
+++ b/transcrypt
@@ -22,7 +22,7 @@ readonly VERSION='2.0.0'
 readonly DEFAULT_CIPHER='aes-256-cbc'
 
 # regular expression used to ensure context name is safe for use in git config
-readonly CONTEXT_REGEX='[a-zA-Z][a-zA-Z0-9-]*'
+readonly CONTEXT_REGEX='[a-z][a-z0-9-]*'
 
 ##### FUNCTIONS
 
@@ -116,7 +116,7 @@ run_safety_checks() {
 	# Do we have a valid context name?
 	full_context_regex="^${CONTEXT_REGEX}$"
 	if [[ ! $CONTEXT =~ $full_context_regex ]]; then
-		die 1 "context name '$CONTEXT' is invalid, must be ASCII followed by zero or more of letter/number/hyphen"
+		die 1 "context name '$CONTEXT' is invalid, must be lowercase ASCII letter followed by zero or more of letter/number/hyphen"
 	fi
 
 	# exit if transcrypt is not in the required state
@@ -297,11 +297,15 @@ save_helper_scripts() {
 
 	cat <<-'EOF' >"${GIT_DIR}/crypt/clean"
 		#!/usr/bin/env bash
-		context_prefix=''
-		if [[ $1 != 'default' ]]; then
-		  context_prefix="$1-"
+		filename=$1
+
+		context=$(git -c core.quotePath=false check-attr crypt-context -- "$filename" | awk 'BEGIN { FS = ": " }; { print $3 }')
+		if [[ $context = 'unspecified' ]]; then
+		  context_prefix=""
+		else
+		  context_prefix="$context-"
 		fi
-		filename=$2
+
 		# ignore empty files
 		if [[ -s $filename ]]; then
 		  # cache STDIN to test if it's already encrypted
@@ -323,10 +327,15 @@ save_helper_scripts() {
 
 	cat <<-'EOF' >"${GIT_DIR}/crypt/smudge"
 		#!/usr/bin/env bash
-		context_prefix=''
-		if [[ $1 != 'default' ]]; then
-		  context_prefix="$1-"
+		filename=$1
+
+		context=$(git -c core.quotePath=false check-attr crypt-context -- "$filename" | awk 'BEGIN { FS = ": " }; { print $3 }')
+		if [[ $context = 'unspecified' ]]; then
+		  context_prefix=""
+		else
+		  context_prefix="$context-"
 		fi
+
 		tempfile=$(mktemp 2>/dev/null || mktemp -t tmp)
 		trap 'rm -f "$tempfile"' EXIT
 		cipher=$(git config --get --local transcrypt.${context_prefix}cipher)
@@ -336,11 +345,15 @@ save_helper_scripts() {
 
 	cat <<-'EOF' >"${GIT_DIR}/crypt/textconv"
 		#!/usr/bin/env bash
-		context_prefix=''
-		if [[ $1 != 'default' ]]; then
-		  context_prefix="$1-"
+		filename=$1
+
+		context=$(git -c core.quotePath=false check-attr crypt-context -- "$filename" | awk 'BEGIN { FS = ": " }; { print $3 }')
+		if [[ $context = 'unspecified' ]]; then
+		  context_prefix=""
+		else
+		  context_prefix="$context-"
 		fi
-		filename=$2
+
 		# ignore empty files
 		if [[ -s $filename ]]; then
 		  cipher=$(git config --get --local transcrypt.${context_prefix}cipher)
@@ -352,14 +365,11 @@ save_helper_scripts() {
 	cat <<-'EOF' >"${GIT_DIR}/crypt/merge"
 		#!/usr/bin/env bash
 
-		# NOTE: The usual merge driver argument numbers are increased by one
-		# because this script is passed the transcrypt context name as $1
-		readonly TRANSCRYPT_CONTEXT=$1
-		readonly BASE=$2
-		readonly LOCAL=$3
-		readonly REMOTE=$4
-		readonly MARKER_SIZE=$5
-		readonly WORKING_COPY_FILE=$6
+		readonly BASE=$1
+		readonly LOCAL=$2
+		readonly REMOTE=$3
+		readonly MARKER_SIZE=$4
+		readonly WORKING_COPY_FILE=$5
 
 		# Look up name of local branch/ref to which changes are being merged
 		OURS_LABEL=$(git rev-parse --abbrev-ref HEAD)
@@ -375,9 +385,9 @@ save_helper_scripts() {
 		fi
 
 		# Decrypt BASE, LOCAL, and REMOTE versions of file being merged
-		echo "$(cat "$BASE" | ./.git/crypt/smudge $TRANSCRYPT_CONTEXT)" > "$BASE"
-		echo "$(cat "$LOCAL" | ./.git/crypt/smudge $TRANSCRYPT_CONTEXT)" > "$LOCAL"
-		echo "$(cat "$REMOTE" | ./.git/crypt/smudge $TRANSCRYPT_CONTEXT)" > "$REMOTE"
+		echo "$(cat "$BASE" | ./.git/crypt/smudge $TRANSCRYPT_CONTEXT $WORKING_COPY_FILE)" > "$BASE"
+		echo "$(cat "$LOCAL" | ./.git/crypt/smudge $TRANSCRYPT_CONTEXT $WORKING_COPY_FILE)" > "$LOCAL"
+		echo "$(cat "$REMOTE" | ./.git/crypt/smudge $TRANSCRYPT_CONTEXT $WORKING_COPY_FILE)" > "$REMOTE"
 
 		# Merge the decrypted files to the temp file named by LOCAL
 		git merge-file --marker-size=$MARKER_SIZE -L "$OURS_LABEL" -L base -L "$THEIRS_LABEL" "$LOCAL" "$BASE" "$REMOTE"
@@ -473,34 +483,42 @@ save_configuration() {
 		# this allows us to support multiple working trees via git-worktree
 		# ...but the --git-common-dir flag was only added in November 2014
 		# shellcheck disable=SC2016
-		git config filter."${CONTEXT_CRYPT}".clean '"$(git rev-parse --git-common-dir)"/crypt/clean '"$CONTEXT"' %f'
+		git config filter.crypt.clean '"$(git rev-parse --git-common-dir)"/crypt/clean %f'
 		# shellcheck disable=SC2016
-		git config filter."${CONTEXT_CRYPT}".smudge '"$(git rev-parse --git-common-dir)"/crypt/smudge '"$CONTEXT"
+		git config filter.crypt.smudge '"$(git rev-parse --git-common-dir)"/crypt/smudge %f'
 		# shellcheck disable=SC2016
-		git config diff."${CONTEXT_CRYPT}".textconv '"$(git rev-parse --git-common-dir)"/crypt/textconv '"$CONTEXT"
+		git config diff.crypt.textconv '"$(git rev-parse --git-common-dir)"/crypt/textconv'
 		# shellcheck disable=SC2016
-		git config merge."${CONTEXT_CRYPT}".driver '"$(git rev-parse --git-common-dir)"/crypt/merge '"$CONTEXT"' %O %A %B %L %P'
+		git config merge.crypt.driver '"$(git rev-parse --git-common-dir)"/crypt/merge %O %A %B %L %P'
 	else
 		# shellcheck disable=SC2016
-		git config filter."${CONTEXT_CRYPT}".clean '"$(git rev-parse --git-dir)"/crypt/clean '"$CONTEXT" ' %f'
+		git config filter.crypt.clean '"$(git rev-parse --git-dir)"/crypt/clean %f'
 		# shellcheck disable=SC2016
-		git config filter."${CONTEXT_CRYPT}".smudge '"$(git rev-parse --git-dir)"/crypt/smudge '"$CONTEXT"
+		git config filter.crypt.smudge '"$(git rev-parse --git-dir)"/crypt/smudge %f'
 		# shellcheck disable=SC2016
-		git config diff."${CONTEXT_CRYPT}".textconv '"$(git rev-parse --git-dir)"/crypt/textconv '"$CONTEXT"
+		git config diff.crypt.textconv '"$(git rev-parse --git-dir)"/crypt/textconv'
 		# shellcheck disable=SC2016
-		git config merge."${CONTEXT_CRYPT}".driver '"$(git rev-parse --git-dir)"/crypt/merge '"$CONTEXT"' %O %A %B %L %P'
+		git config merge.crypt.driver '"$(git rev-parse --git-dir)"/crypt/merge %O %A %B %L %P'
 	fi
-	git config filter."${CONTEXT_CRYPT}".required 'true'
-	git config diff."${CONTEXT_CRYPT}".cachetextconv 'true'
-	git config diff."${CONTEXT_CRYPT}".binary 'true'
+	git config filter.crypt.required 'true'
+	git config diff.crypt.cachetextconv 'true'
+	git config diff.crypt.binary 'true'
 	git config merge.renormalize 'true'
-	git config merge."${CONTEXT_CRYPT}".name 'Merge transcrypt secret files'
-
-	# add a git alias for listing encrypted files in specific context, including 'default'
-	git config alias."${CONTEXT_LS_CRYPT}" "!git -c core.quotePath=false ls-files | git -c core.quotePath=false check-attr --stdin filter | awk 'BEGIN { FS = \":\" }; / ${CONTEXT_CRYPT}$/{ print \$1 }'"
+	git config merge.crypt.name 'Merge transcrypt secret files'
 
 	# add git alias for listing ALL encrypted files regardless of context
-	git config alias.ls-crypt "!git -c core.quotePath=false ls-files | git -c core.quotePath=false check-attr --stdin filter | awk 'BEGIN { FS = \":\" }; / (${CONTEXT_REGEX}-)?crypt$/{ print \$1 }'"
+	git config alias.ls-crypt "!git -c core.quotePath=false ls-files | git -c core.quotePath=false check-attr --stdin filter | awk 'BEGIN { FS = \":\" }; / crypt$/{ print \$1 }'"
+
+	# add a git alias for listing encrypted files in specific context, including 'default'
+	if [[ "$CONTEXT" = 'default' ]]; then
+		# The 'ls-default-crypt' alias calls the 'ls-crypt' alias to get all crypt-ed
+		# files then filters those to any *without* a 'crypt-context' attr (unspecified).
+		# This is to avoid very difficult processing of multi-line output if we needed
+		# to fetch the two attrs 'filter' and 'crypt-context' from check-attr at once.
+		git config alias."${CONTEXT_LS_CRYPT}" "!git ls-crypt | git -c core.quotePath=false check-attr --stdin crypt-context | awk 'BEGIN { FS = \":\" }; / unspecified$/{ print \$1 }'"
+	else
+		git config alias."${CONTEXT_LS_CRYPT}" "!git -c core.quotePath=false ls-files | git -c core.quotePath=false check-attr --stdin crypt-context | awk 'BEGIN { FS = \":\" }; / ${CONTEXT}$/{ print \$1 }'"
+	fi
 }
 
 # display the current configuration settings
@@ -537,20 +555,10 @@ display_configuration() {
 
 # remove transcrypt-related settings from the repository's git config
 clean_gitconfig() {
-	# Remove context-specific settings
-	for context in $(get_contexts_from_git_config); do
-		if [[ $context != 'default' ]]; then
-			context_crypt="$context-crypt"
-		else
-			context_crypt='crypt'
-		fi
-		git config --remove-section filter.${context_crypt} 2>/dev/null || true
-		git config --remove-section diff.${context_crypt} 2>/dev/null || true
-		git config --remove-section merge.${context_crypt} 2>/dev/null || true
-	done
-
-	# Remove global transcrypt settings
 	git config --remove-section transcrypt 2>/dev/null || true
+	git config --remove-section filter.crypt 2>/dev/null || true
+	git config --remove-section diff.crypt 2>/dev/null || true
+	git config --remove-section merge.crypt 2>/dev/null || true
 	git config --unset merge.renormalize
 
 	# remove the merge section if it's now empty
@@ -696,24 +704,14 @@ uninstall_transcrypt() {
 		fi
 
 		# remove any defined crypt patterns in gitattributes
-		for context in $(get_contexts_from_git_attributes); do
-			if [[ $context != 'default' ]]; then
-				context_crypt="$context-crypt"
-			else
-				context_crypt='crypt'
-			fi
-
-			case $OSTYPE in
-			darwin*)
-				/usr/bin/sed -i '' "/filter=${context_crypt} diff=${context_crypt}[ \t]*$/d" "$GIT_ATTRIBUTES"
-				/usr/bin/sed -i '' "/filter=${context_crypt} diff=${context_crypt} merge=${context_crypt}[ \t]*$/d" "$GIT_ATTRIBUTES"
-				;;
-			linux*)
-				sed -i "/filter=${context_crypt} diff=${context_crypt}[ \t]*$/d" "$GIT_ATTRIBUTES"
-				sed -i "/filter=${context_crypt} diff=${context_crypt} merge=${context_crypt}[ \t]*$/d" "$GIT_ATTRIBUTES"
-				;;
-			esac
-		done
+		case $OSTYPE in
+		darwin*)
+			/usr/bin/sed -i '' "/filter=crypt diff=crypt\( merge=crypt\)*\( crypt-context=[^ \t]*\)*[ \t]*$/d" "$GIT_ATTRIBUTES"
+			;;
+		linux*)
+			sed -i "/filter=crypt diff=crypt\( merge=crypt\)*\( crypt-context=[^ \t]*\)*[ \t]*$/d" "$GIT_ATTRIBUTES"
+			;;
+		esac
 
 		if [[ ! $upgrade ]]; then
 			printf 'The transcrypt configuration has been completely removed from the repository.\n'
@@ -886,14 +884,14 @@ get_contexts_from_git_attributes() {
 		echo "0"
 	fi
 	# Capture contents of .gitattributes without comments (leading # hash)
-	attrs=$(sed '/^.*#/d' <"$GIT_ATTRIBUTES")
-	extract_context_name_regex="filter=(${CONTEXT_REGEX})-crypt"
+	attr_lines=$(sed '/^.*#/d' <"$GIT_ATTRIBUTES")
+	extract_context_name_regex="crypt-context=(${CONTEXT_REGEX})"
 	contexts=()
-	for attr in $attrs; do
-		if [[ $attr =~ 'filter=crypt' ]]; then
-			contexts+=('default')
-		elif [[ $attr =~ $extract_context_name_regex ]]; then
+	for attr_line in $attr_lines; do
+		if [[ $attr_line =~ $extract_context_name_regex ]]; then
 			contexts+=(${BASH_REMATCH[1]})
+		elif [[ $attr_line =~ 'filter=crypt' ]]; then
+			contexts+=('default')
 		fi
 	done
 	if [ "${contexts:-}" ]; then
@@ -1087,9 +1085,11 @@ help() {
 		         # Initialise a new context "ts" for top-secret files
 		         $ transcrypt --context=ts
 
-		         # Use context name as a prefix to 'crypt' in .gitattributes
-		         $ echo 'ts_file  filter=ts-crypt diff=ts-crypt merge=ts-crypt' \
-				        >> .gitattributes
+		         # Add extra 'crypt-context=ts' attribute in .gitattributes
+		         $ echo \
+				     'ts_file  filter=crypt diff=crypt merge=crypt crypt-context=ts' \
+				     >> .gitattributes
+
 		         $ git add .gitattributes ts_file
 		         $ git commit -m 'Add encrypted version of a top-secret file'
 
@@ -1249,7 +1249,6 @@ if [[ $context ]]; then
 	readonly CONTEXT_DESC_SUFFIX=" for context '$CONTEXT'"
 	readonly CONTEXT_TRANSCRYPT_CIPHER=transcrypt.${CONTEXT}-cipher
 	readonly CONTEXT_TRANSCRYPT_PASSWORD=transcrypt.${CONTEXT}-password
-	readonly CONTEXT_CRYPT=${CONTEXT}-crypt
 	# For ls-crypt aliases we want one for each context, including 'default'
 	readonly CONTEXT_LS_CRYPT="ls-$CONTEXT-crypt"
 else
@@ -1257,7 +1256,6 @@ else
 	readonly CONTEXT_DESC_SUFFIX=''
 	readonly CONTEXT_TRANSCRYPT_CIPHER=transcrypt.cipher
 	readonly CONTEXT_TRANSCRYPT_PASSWORD=transcrypt.password
-	readonly CONTEXT_CRYPT=crypt
 	# For ls-crypt aliases we want one for each context, including 'default'
 	readonly CONTEXT_LS_CRYPT="ls-$CONTEXT-crypt"
 fi

--- a/transcrypt
+++ b/transcrypt
@@ -272,7 +272,7 @@ confirm_rekey() {
 # automatically stage rekeyed files in preparation for the user to commit them
 stage_rekeyed_files() {
 	local encrypted_files
-	encrypted_files=$(git ls-crypt-all)
+	encrypted_files=$(git ls-crypt)
 	if [[ $encrypted_files ]] && [[ $IS_BARE == 'false' ]]; then
 		# touch all encrypted files to prevent stale stat info
 		cd "$REPO" || die 1 'could not change into the "%s" directory' "$REPO"
@@ -389,11 +389,11 @@ save_configuration() {
 	git config diff.${CONTEXT_CRYPT}.binary 'true'
 	git config merge.renormalize 'true'
 
-	# add a git alias for listing encrypted files in context
-	git config alias.ls-${CONTEXT_CRYPT} "!git ls-files | git check-attr --stdin filter | awk 'BEGIN { FS = \":\" }; / ${CONTEXT_CRYPT}$/{ print \$1 }'"
+	# add a git alias for listing encrypted files in specific context, including 'default'
+	git config alias.${CONTEXT_LS_CRYPT} "!git ls-files | git check-attr --stdin filter | awk 'BEGIN { FS = \":\" }; / ${CONTEXT_CRYPT}$/{ print \$1 }'"
 
-	# add a git alias for listing ALL encrypted files regardless of context
-	git config alias.ls-crypt-all "!git ls-files | git check-attr --stdin filter | awk 'BEGIN { FS = \":\" }; / (${CONTEXT_REGEX}-)?crypt$/{ print \$1 }'"
+	# add git alias for listing ALL encrypted files regardless of context
+	git config alias.ls-crypt "!git ls-files | git check-attr --stdin filter | awk 'BEGIN { FS = \":\" }; / (${CONTEXT_REGEX}-)?crypt$/{ print \$1 }'"
 }
 
 # display the current configuration settings
@@ -463,7 +463,7 @@ force_checkout() {
 		# this would normally delete uncommitted changes in the working directory,
 		# but we already made sure the repo was clean during the safety checks
 		local encrypted_files
-		encrypted_files=$(git ls-$CONTEXT_CRYPT)
+		encrypted_files=$(git $CONTEXT_LS_CRYPT)
 		cd "$REPO" || die 1 'could not change into the "%s" directory' "$REPO"
 		IFS=$'\n'
 		for file in $encrypted_files; do
@@ -532,21 +532,17 @@ uninstall_transcrypt() {
 
 		# touch all encrypted files to prevent stale stat info
 		local encrypted_files
-		encrypted_files=$(git ls-crypt-all)
+		encrypted_files=$(git ls-crypt)
 		if [[ $encrypted_files ]] && [[ $IS_BARE == 'false' ]]; then
 			cd "$REPO" || die 1 'could not change into the "%s" directory' "$REPO"
 			# shellcheck disable=SC2086
 			touch $encrypted_files
 		fi
 
-		# remove the `git ls-crypt` aliases
-		git config --unset alias.ls-crypt-all
+		# remove the `git ls-crypt` global alias and each context-specific alias
+		git config --unset alias.ls-crypt
 		for context in $contexts_in_git_config; do
-			context_prefix=''
-			if [[ $context != 'default' ]]; then
-				context_prefix="$context-"
-			fi
-			git config --unset alias.ls-${context_prefix}crypt
+			git config --unset alias.ls-${context}-crypt
 		done
 
 		# remove the alias section if it's now empty
@@ -583,7 +579,7 @@ uninstall_transcrypt() {
 list_files() {
 	if [[ $IS_BARE == 'false' ]]; then
 		cd "$REPO" || die 1 'could not change into the "%s" directory' "$REPO"
-		git ls-crypt-all
+		git ls-crypt
 	fi
 }
 
@@ -598,7 +594,7 @@ show_raw_file() {
 			die 1 'the file "%s" is not currently being tracked by git' "$show_file"
 		fi
 	elif [[ $show_file == '*' ]]; then
-		file_paths=$(git ls-$CONTEXT_CRYPT)
+		file_paths=$(git ls-crypt)
 	else
 		die 1 'the file "%s" does not exist' "$show_file"
 	fi
@@ -1017,6 +1013,9 @@ readonly CONTEXT_TRANSCRYPT_VERSION=transcrypt.${CONTEXT_PREFIX:-}version
 readonly CONTEXT_TRANSCRYPT_CIPHER=transcrypt.${CONTEXT_PREFIX:-}cipher
 readonly CONTEXT_TRANSCRYPT_PASSWORD=transcrypt.${CONTEXT_PREFIX:-}password
 readonly CONTEXT_CRYPT=${CONTEXT_PREFIX:-}crypt
+
+# For ls-crypt aliases we want one for each context, including 'default'
+readonly CONTEXT_LS_CRYPT="ls-$CONTEXT-crypt"
 
 # whether or not transcrypt is already configured
 readonly CONFIGURED=$(git config --get --local $CONTEXT_TRANSCRYPT_VERSION 2>/dev/null)

--- a/transcrypt
+++ b/transcrypt
@@ -511,8 +511,8 @@ display_configuration() {
 	current_password=$(git config --get --local "$CONTEXT_TRANSCRYPT_PASSWORD")
 	local escaped_password=${current_password//\'/\'\\\'\'}
 
-	contexts=$(get_contexts)
-	contexts_count=$(echo $contexts | tr ' ' '\n' | wc -l | tr -d ' ')
+	contexts=$(get_contexts_from_git_config)
+	contexts_count="$(count_items_in_list "$contexts")"
 
 	printf 'The current repository was configured using transcrypt version %s\n' "$CONFIGURED"
 	printf "and has the following configuration%s:\n\n" "$CONTEXT_DESC_SUFFIX"
@@ -863,7 +863,7 @@ import_gpg() {
 	password=$(printf '%s' "$configuration" | grep '^password' | cut -d'=' -f 2-)
 }
 
-# Echo array of context names as defined in the git config
+# Echo space-delimited list of context names defined in the git config
 get_contexts_from_git_config() {
 	config_names=$(git config --local --name-only --list | grep transcrypt)
 	extract_context_name_regex="transcrypt\.(${CONTEXT_REGEX})-password"
@@ -875,20 +875,20 @@ get_contexts_from_git_config() {
 			contexts+=(${BASH_REMATCH[1]})
 		fi
 	done
-	if [ ! -z "${contexts:-}" ]; then
-		printf "%q " "${contexts[@]:-}"
+	if [ "${contexts:-}" ]; then
+		echo $(trim `printf "%q " "${contexts[@]}"`)
 	fi
 }
 
-# Echo array of context names as defined in the .gitattributes file
+# Echo space-delimited list of context names defined in the .gitattributes file
 get_contexts_from_git_attributes() {
 	if [[ ! -f $GIT_ATTRIBUTES ]]; then
-		return 0
+		echo "0"
 	fi
-	contexts=()
 	# Capture contents of .gitattributes without comments (leading # hash)
 	attrs=$(sed '/^.*#/d' <"$GIT_ATTRIBUTES")
 	extract_context_name_regex="filter=(${CONTEXT_REGEX})-crypt"
+	contexts=()
 	for attr in $attrs; do
 		if [[ $attr =~ 'filter=crypt' ]]; then
 			contexts+=('default')
@@ -896,21 +896,31 @@ get_contexts_from_git_attributes() {
 			contexts+=(${BASH_REMATCH[1]})
 		fi
 	done
-	if [ ! -z "${contexts:-}" ]; then
-		printf "%q " "${contexts[@]:-}"
+	if [ "${contexts:-}" ]; then
+		echo $(trim `printf "%q " "${contexts[@]}"`)
 	fi
 }
 
-# Echo all context names, sorted and distinct, as defined in the git config or .gitattributes file
+# Echo all context names, sorted and distinct, from the git config or .gitattributes
 get_contexts() {
 	combined_contexts="$(get_contexts_from_git_config) $(get_contexts_from_git_attributes)"
 	sorted_contexts=$(echo "$combined_contexts" | tr ' ' '\n' | sort -u | tr '\n' ' ')
-	if [ ! -z "${sorted_contexts:-}" ]; then
+	if [ "${sorted_contexts:-}" ]; then
 		echo "$(trim $sorted_contexts)"
 	fi
 }
 
-# Utility function returns a truthy value if value $1 is in bash array $2
+# Echo the number of items in a space-delimited list given as $1
+count_items_in_list() {
+	local trimmed=$(trim $1)
+	if [[ ! "$trimmed" ]]; then
+		return 0
+	fi
+	local just_spaces="${trimmed//[^ ]/}"
+	echo $(( ${#just_spaces} + 1 ))
+}
+
+# Utility function returns a truthy value if value $1 is in bash list or array $2
 # Based on https://stackoverflow.com/a/8574392/4970
 is_item_in_array() {
   local e match="$1"

--- a/transcrypt
+++ b/transcrypt
@@ -225,6 +225,9 @@ confirm_configuration() {
 	printf '  GIT_DIR:        %s\n' "$GIT_DIR"
 	printf '  GIT_ATTRIBUTES: %s\n\n' "$GIT_ATTRIBUTES"
 	printf 'The following configuration will be saved:\n\n'
+	if [[ $CONTEXT != 'default' ]]; then
+		printf '  CONTEXT:  %s\n' "$CONTEXT"
+	fi
 	printf '  CIPHER:   %s\n' "$cipher"
 	printf '  PASSWORD: %s\n\n' "$password"
 	printf 'Does this look correct? [Y/n] '
@@ -248,6 +251,9 @@ confirm_rekey() {
 	printf '  GIT_DIR:        %s\n' "$GIT_DIR"
 	printf '  GIT_ATTRIBUTES: %s\n\n' "$GIT_ATTRIBUTES"
 	printf 'The following configuration will be saved:\n\n'
+	if [[ $CONTEXT != 'default' ]]; then
+		printf '  CONTEXT:  %s\n' "$CONTEXT"
+	fi
 	printf '  CIPHER:   %s\n' "$cipher"
 	printf '  PASSWORD: %s\n\n' "$password"
 	printf 'You are about to re-encrypt all encrypted files using new credentials.\n'
@@ -398,10 +404,9 @@ display_configuration() {
 	current_password=$(git config --get --local $CONTEXT_TRANSCRYPT_PASSWORD)
 	local escaped_password=${current_password//\'/\'\\\'\'}
 
-	current_context_desc=''
-	if [[ $CONTEXT != 'default' ]]; then
-		current_context_desc=" for context '$CONTEXT'"
-	fi
+	contexts=$(get_contexts)
+	contexts_array=($contexts)  # Convert list to bash array so we can count elements
+	current_context_desc=" for context '$CONTEXT'"
 
 	printf 'The current repository was configured using transcrypt version %s\n' "$CONFIGURED"
 	printf "and has the following configuration${current_context_desc}:\n\n"
@@ -413,7 +418,11 @@ display_configuration() {
 	fi
 	printf '  CIPHER:   %s\n' "$current_cipher"
 	printf '  PASSWORD: %s\n\n' "$current_password"
-	printf 'Copy and paste the following command to initialize a cloned repository:\n\n'
+	if [[ "${#contexts_array[@]}" -gt "1" ]]; then
+		printf 'The repository has %s contexts: %s\n\n' "${#contexts_array[@]}" "$contexts"
+	fi
+	printf 'Copy and paste the following command to initialize a cloned\n'
+	printf "repository${current_context_desc}:\n\n"
 	if [[ $CONTEXT != 'default' ]]; then
 		printf "  transcrypt -C $CONTEXT -c %s -p '%s'\n" "$current_cipher" "$escaped_password"
 	else
@@ -621,7 +630,12 @@ export_gpg() {
 
 	local gpg_encrypt_cmd="gpg --batch --recipient $gpg_recipient --trust-model always --yes --armor --quiet --encrypt -"
 	printf 'password=%s\ncipher=%s\n' "$current_password" "$current_cipher" | $gpg_encrypt_cmd >"${GIT_DIR}/crypt/${gpg_recipient}.asc"
-	printf "The transcrypt configuration has been encrypted and exported to:\n%s/crypt/%s.asc\n" "$GIT_DIR" "$gpg_recipient"
+
+	current_context_desc=''
+	if [[ $CONTEXT != 'default' ]]; then
+		current_context_desc=" for context '$CONTEXT'"
+	fi
+	printf "The transcrypt configuration${current_context_desc} has been encrypted and exported to:\n%s/crypt/%s.asc\n" "$GIT_DIR" "$gpg_recipient"
 }
 
 # import password and cipher from a gpg encrypted file
@@ -655,6 +669,7 @@ import_gpg() {
 	password=$(printf '%s' "$configuration" | grep '^password' | cut -d'=' -f 2-)
 }
 
+# Echo array of context names as defined in the git config
 get_contexts_from_git_config() {
 	contexts=()
 	config_name=$(git config --local --name-only --list)
@@ -670,6 +685,7 @@ get_contexts_from_git_config() {
 	echo ${contexts[@]+"${contexts[@]}"}
 }
 
+# Echo array of context names as defined in the .gitattributes file
 get_contexts_from_git_attributes() {
 	if [[ ! -f $GIT_ATTRIBUTES ]]; then
 		return 0
@@ -689,11 +705,15 @@ get_contexts_from_git_attributes() {
 	echo ${contexts[@]+"${contexts[@]}"}
 }
 
+# Echo all context names, sorted and distinct, as defined in the git config or .gitattributes file
 get_contexts() {
 	combined_contexts="$(get_contexts_from_git_config) $(get_contexts_from_git_attributes)"
-	echo $(printf '%s\n' $combined_contexts | sort -u | tr '\n' ' ')
+	sorted_contexts=$(printf '%s\n' $combined_contexts | sort -u | tr '\n' ' ')
+	# Avoid 'unbound variable' if array is empty: https://stackoverflow.com/a/7577209/4970
+	echo ${sorted_contexts[@]+"${sorted_contexts[@]}"}
 }
 
+# Utility function returns a truthy value if value $1 is in bash array $2
 is_item_in_array() {
 	# Based on https://stackoverflow.com/a/47541882/4970
 	return $(printf '%s\n' $2 | grep -q "^${1}$")
@@ -703,15 +723,15 @@ list_contexts() {
 	in_git_config=$(get_contexts_from_git_config)
 	in_git_attributes=$(get_contexts_from_git_attributes)
 	for context in $(get_contexts); do
-		config_desc='not configured'
+		config_status='not configured'
 		if is_item_in_array $context "${in_git_config[@]}"; then
-			config_desc='configured'
+			config_status='configured'
 		fi
-		attr_desc='not in .gitattributes'
+		attr_status='not in .gitattributes'
 		if is_item_in_array $context "${in_git_attributes[@]}"; then
-			attr_desc='in .gitattributes'
+			attr_status='in .gitattributes'
 		fi
-		echo "$context ($config_desc, $attr_desc)"
+		echo "$context ($config_status, $attr_status)"
 	done
 }
 
@@ -788,9 +808,9 @@ help() {
 		            import the password and cipher from a gpg encrypted file
 
 		     -C, --context=CONTEXT
-		            name for a context that can use a different passphrase
-		            and cipher from the "default" context. Use this to encrypt
-		            files with more than one passphrase in the same repository.
+		            name for a context that can use a different passphrase and cipher
+		            from the "default" context;  use this advanced option, to permit
+		            encrypting different files with different passphrases
 
 		     --list-contexts
 		            list all contexts configured in the repository
@@ -832,6 +852,24 @@ help() {
 		     If  the  origin  repository  has  just rekeyed, all clones should flush
 		     their transcrypt credentials, fetch and merge the new  encrypted  files
 		     via Git, and then re-configure transcrypt with the new credentials.
+
+		     To use multiple passphrases for files with different security contexts,
+		     specify a new  context name  when you initialise  transcrypt or display
+		     credentials. You can list all the contexts configured in the repository
+			 and their status. For example:
+
+		         # Initialise a new context "ts" for top-secret files
+		         $ transcrypt --context=ts
+
+		         # Use context name as a prefix to 'crypt' in .gitattributes
+		         $ echo 'ts_file  filter=ts-crypt diff=ts-crypt' >> .gitattributes
+		         $ git add .gitattributes ts_file
+		         $ git commit -m 'Add encrypted version of a top-secret file'
+
+		         # List all contexts and their status
+		         $ transcrypt --list-contexts
+		         default (configured, in .gitattributes)
+		         ts (configured, in .gitattributes)
 
 		AUTHOR
 		     Aaron Bull Schaefer <aaron@elasticdog.com>

--- a/transcrypt
+++ b/transcrypt
@@ -666,10 +666,14 @@ get_contexts_from_git_config() {
 			contexts+=" ${BASH_REMATCH[1]}"
 		fi
 	done
-	echo $contexts
+	# Avoid 'unbound variable' if array is empty: https://stackoverflow.com/a/7577209/4970
+	echo ${contexts[@]+"${contexts[@]}"}
 }
 
 get_contexts_from_git_attributes() {
+	if [[ ! -f $GIT_ATTRIBUTES ]]; then
+		return 0
+	fi
 	contexts=()
 	# Capture contents of .gitattributes without comments (leading # hash)
 	attrs=$(cat $GIT_ATTRIBUTES | sed '/^.*#/d')
@@ -681,7 +685,8 @@ get_contexts_from_git_attributes() {
 			contexts+=" ${BASH_REMATCH[1]}"
 		fi
 	done
-	echo $contexts
+	# Avoid 'unbound variable' if array is empty: https://stackoverflow.com/a/7577209/4970
+	echo ${contexts[@]+"${contexts[@]}"}
 }
 
 get_contexts() {

--- a/transcrypt
+++ b/transcrypt
@@ -298,11 +298,12 @@ save_helper_scripts() {
 		#!/usr/bin/env bash
 		filename=$1
 
-		context=$(git -c core.quotePath=false check-attr crypt-context -- "$filename" | awk 'BEGIN { FS = ": " }; { print $3 }')
-		if [[ $context = 'unspecified' ]]; then
+		# Look up file's context name from .gitattributes, fall back to no context
+		context_name=$(git -c core.quotePath=false check-attr crypt-context -- "$filename" | awk 'BEGIN { FS = ": " }; { print $3 }')
+		if [[ $context_name = 'unspecified' ]]; then
 		  context_prefix=""
 		else
-		  context_prefix="$context-"
+		  context_prefix="$context_name-"
 		fi
 
 		# ignore empty files
@@ -328,11 +329,12 @@ save_helper_scripts() {
 		#!/usr/bin/env bash
 		filename=$1
 
-		context=$(git -c core.quotePath=false check-attr crypt-context -- "$filename" | awk 'BEGIN { FS = ": " }; { print $3 }')
-		if [[ $context = 'unspecified' ]]; then
+		# Look up file's context name from .gitattributes, fall back to no context
+		context_name=$(git -c core.quotePath=false check-attr crypt-context -- "$filename" | awk 'BEGIN { FS = ": " }; { print $3 }')
+		if [[ $context_name = 'unspecified' ]]; then
 		  context_prefix=""
 		else
-		  context_prefix="$context-"
+		  context_prefix="$context_name-"
 		fi
 
 		tempfile=$(mktemp 2>/dev/null || mktemp -t tmp)
@@ -346,11 +348,12 @@ save_helper_scripts() {
 		#!/usr/bin/env bash
 		filename=$1
 
-		context=$(git -c core.quotePath=false check-attr crypt-context -- "$filename" | awk 'BEGIN { FS = ": " }; { print $3 }')
-		if [[ $context = 'unspecified' ]]; then
+		# Look up file's context name from .gitattributes, fall back to no context
+		context_name=$(git -c core.quotePath=false check-attr crypt-context -- "$filename" | awk 'BEGIN { FS = ": " }; { print $3 }')
+		if [[ $context_name = 'unspecified' ]]; then
 		  context_prefix=""
 		else
-		  context_prefix="$context-"
+		  context_prefix="$context_name-"
 		fi
 
 		# ignore empty files
@@ -878,7 +881,7 @@ get_contexts_from_git_config() {
 # Echo space-delimited list of context names defined in the .gitattributes file
 get_contexts_from_git_attributes() {
 	if [[ ! -f $GIT_ATTRIBUTES ]]; then
-		echo "0"
+		echo ""
 	fi
 	# Capture contents of .gitattributes without comments (leading # hash)
 	attr_lines=$(sed '/^.*#/d' <"$GIT_ATTRIBUTES")

--- a/transcrypt
+++ b/transcrypt
@@ -127,12 +127,8 @@ run_safety_checks() {
 	fi
 
 	# exit if transcrypt is not in the required state
-	if [[ $ignore_config_status ]]; then
-		: # no-op, no need to check $CONFIGURED_CONTEXTS status
-	elif [[ $requires_existing_config ]] && [[ ! $CONFIGURED_CONTEXTS ]]; then
+	if [[ $requires_existing_config ]] && [[ ! $CONFIGURED_CONTEXTS ]]; then
 		die 1 'the current repository is not configured'
-	elif [[ ! $requires_existing_config ]] && is_item_in_array "$CONTEXT" "$CONFIGURED_CONTEXTS"; then
-		die 1 "the current repository is already configured${CONTEXT_DESC_SUFFIX}; see --display"
 	fi
 
 	# check for dependencies
@@ -473,6 +469,16 @@ save_helper_hooks() {
 
 # write the configuration to the repository's git config
 save_configuration() {
+	# prevent clobbering existing configuration
+	# shellcheck disable=SC2086
+	if is_item_in_array "$CONTEXT" ${CONFIGURED_CONTEXTS}; then
+		if [[ "$CONTEXT" = 'default' ]]; then
+			die 1 "the current repository is already configured; see 'transcrypt --display'"
+		else
+			die 1 "the current repository is already configured${CONTEXT_DESC_SUFFIX}; see 'transcrypt --context=$CONTEXT --display'"
+		fi
+	fi
+
 	save_helper_scripts
 	save_helper_hooks
 
@@ -1137,23 +1143,19 @@ upgrade=''
 # used to bypass certain safety checks
 requires_existing_config=''
 requires_clean_repo='true'
-ignore_config_status='' # Set for operations where config can exist or not
 
 # parse command line options
 while [[ "${1:-}" != '' ]]; do
 	case $1 in
 	-C | --context)
 		context=$2
-		ignore_config_status='true'
 		shift
 		;;
 	--context=*)
 		context=${1#*=}
-		ignore_config_status='true'
 		;;
 	--list-contexts)
 		list_ctxs='true'
-		ignore_config_status='true'
 		requires_clean_repo=''
 		;;
 	-c | --cipher)
@@ -1202,7 +1204,6 @@ while [[ "${1:-}" != '' ]]; do
 	-l | --list)
 		list='true'
 		requires_clean_repo=''
-		ignore_config_status='true'
 		;;
 	-s | --show-raw)
 		show_file=$2

--- a/transcrypt
+++ b/transcrypt
@@ -303,7 +303,7 @@ save_helper_scripts() {
 		if [[ $context_name = 'unspecified' ]]; then
 		  context_prefix=""
 		else
-		  context_prefix="$context_name-"
+		  context_prefix="$context_name."
 		fi
 
 		# ignore empty files
@@ -334,7 +334,7 @@ save_helper_scripts() {
 		if [[ $context_name = 'unspecified' ]]; then
 		  context_prefix=""
 		else
-		  context_prefix="$context_name-"
+		  context_prefix="$context_name."
 		fi
 
 		tempfile=$(mktemp 2>/dev/null || mktemp -t tmp)
@@ -353,7 +353,7 @@ save_helper_scripts() {
 		if [[ $context_name = 'unspecified' ]]; then
 		  context_prefix=""
 		else
-		  context_prefix="$context_name-"
+		  context_prefix="$context_name."
 		fi
 
 		# ignore empty files
@@ -690,9 +690,13 @@ uninstall_transcrypt() {
 			touch $encrypted_files
 		fi
 
-		# remove the `git ls-crypt` global alias and each context-specific alias
+		# remove the `git ls-crypt` global alias and context-specific settings
 		git config --unset alias.ls-crypt
 		for context in $contexts_in_git_config; do
+			# remove context cipher and password settings
+			git config --remove-section transcrypt.${context} 2>/dev/null || true
+
+			# remove context ls-crypt alias variant
 			git config --unset alias.ls-crypt-"${context}"
 		done
 
@@ -864,7 +868,7 @@ import_gpg() {
 # Echo space-delimited list of context names defined in the git config
 get_contexts_from_git_config() {
 	config_names=$(git config --local --name-only --list | grep transcrypt)
-	extract_context_name_regex="transcrypt\.(${CONTEXT_REGEX})-password"
+	extract_context_name_regex="transcrypt\.(${CONTEXT_REGEX}).password"
 	contexts=()
 	for name in $config_names; do
 		if [[ "$name" = "transcrypt.password" ]]; then
@@ -1247,8 +1251,8 @@ done
 if [[ $context ]]; then
 	readonly CONTEXT=$context
 	readonly CONTEXT_DESC_SUFFIX=" for context '$CONTEXT'"
-	readonly CONTEXT_TRANSCRYPT_CIPHER=transcrypt.${CONTEXT}-cipher
-	readonly CONTEXT_TRANSCRYPT_PASSWORD=transcrypt.${CONTEXT}-password
+	readonly CONTEXT_TRANSCRYPT_CIPHER=transcrypt.${CONTEXT}.cipher
+	readonly CONTEXT_TRANSCRYPT_PASSWORD=transcrypt.${CONTEXT}.password
 	# For ls-crypt aliases we want one for each context, including 'default'
 	readonly CONTEXT_LS_CRYPT="ls-crypt-$CONTEXT"
 else

--- a/transcrypt
+++ b/transcrypt
@@ -423,12 +423,19 @@ display_configuration() {
 
 # remove transcrypt-related settings from the repository's git config
 clean_gitconfig() {
-	git config --remove-section transcrypt 2>/dev/null || true
-	git config --remove-section filter.crypt 2>/dev/null || true
-	git config --remove-section diff.crypt 2>/dev/null || true
-	git config --unset merge.renormalize
+	# Remove context-specific settings
+	for context in $(get_contexts_from_git_config); do
+		context_prefix=''
+		if [[ $context != 'default' ]]; then
+		  context_prefix="$context-"
+		fi
+		git config --remove-section filter.${context_prefix}crypt 2>/dev/null || true
+		git config --remove-section diff.${context_prefix}crypt 2>/dev/null || true
+	done
 
-	# TODO Remove context-specific config sections
+	# Remove global transcrypt settings
+	git config --remove-section transcrypt 2>/dev/null || true
+	git config --unset merge.renormalize
 
 	# remove the merge section if it's now empty
 	local merge_values
@@ -504,6 +511,8 @@ uninstall_transcrypt() {
 
 	# only uninstall if the user explicitly confirmed
 	if [[ $answer =~ $YES_REGEX ]]; then
+		contexts_in_git_config=$(get_contexts_from_git_config)
+
 		clean_gitconfig
 
 		# remove helper scripts
@@ -521,9 +530,15 @@ uninstall_transcrypt() {
 			touch $encrypted_files
 		fi
 
-		# remove the `git ls-crypt` alias
-		# TODO Remove context-specific ls-*-crypt aliases
+		# remove the `git ls-crypt` aliases
 		git config --unset alias.ls-crypt-all
+		for context in $contexts_in_git_config; do
+			context_prefix=''
+			if [[ $context != 'default' ]]; then
+				context_prefix="$context-"
+			fi
+			git config --unset alias.ls-${context_prefix}crypt
+		done
 
 		# remove the alias section if it's now empty
 		local alias_values
@@ -533,15 +548,21 @@ uninstall_transcrypt() {
 		fi
 
 		# remove any defined crypt patterns in gitattributes
-		# TODO Remove context-specific *-crypt patterns
-		case $OSTYPE in
-		darwin*)
-			/usr/bin/sed -i '' '/filter=crypt diff=crypt[ \t]*$/d' "$GIT_ATTRIBUTES"
-			;;
-		linux*)
-			sed -i '/filter=crypt diff=crypt[ \t]*$/d' "$GIT_ATTRIBUTES"
-			;;
-		esac
+		for context in $(get_contexts_from_git_attributes); do
+			context_prefix=''
+			if [[ $context != 'default' ]]; then
+				context_prefix="$context-"
+			fi
+
+			case $OSTYPE in
+			darwin*)
+				/usr/bin/sed -i '' '/filter='$context_prefix'crypt diff='$context_prefix'crypt[ \t]*$/d' "$GIT_ATTRIBUTES"
+				;;
+			linux*)
+				sed -i '/filter='$context_prefix'crypt diff='$context_prefix'crypt[ \t]*$/d' "$GIT_ATTRIBUTES"
+				;;
+			esac
+		done
 
 		printf 'The transcrypt configuration has been completely removed from the repository.\n'
 	else

--- a/transcrypt
+++ b/transcrypt
@@ -1091,11 +1091,11 @@ help() {
 		     credentials. You can list all the contexts configured in the repository
 			 and their status. For example:
 
-		         # Initialise a new context "TS" for top-secret files
-		         $ transcrypt --context=TS
+		         # Initialise a new context "ts" for top-secret files
+		         $ transcrypt --context=ts
 
 		         # Use context name as a prefix to 'crypt' in .gitattributes
-		         $ echo 'ts_file  filter=TS-crypt diff=TS-crypt merge=TS-crypt' \
+		         $ echo 'ts_file  filter=ts-crypt diff=ts-crypt merge=ts-crypt' \
 				        >> .gitattributes
 		         $ git add .gitattributes ts_file
 		         $ git commit -m 'Add encrypted version of a top-secret file'
@@ -1103,7 +1103,7 @@ help() {
 		         # List all contexts and their status
 		         $ transcrypt --list-contexts
 		         default (configured, in .gitattributes)
-		         TS (configured, in .gitattributes)
+		         ts (configured, in .gitattributes)
 
 		AUTHOR
 		     Aaron Bull Schaefer <aaron@elasticdog.com>

--- a/transcrypt
+++ b/transcrypt
@@ -299,11 +299,10 @@ save_helper_scripts() {
 		filename=$1
 
 		# Look up file's context name from .gitattributes, fall back to no context
+		context_config_group=""
 		context_name=$(git -c core.quotePath=false check-attr crypt-context -- "$filename" | awk 'BEGIN { FS = ": " }; { print $3 }')
-		if [[ $context_name = 'unspecified' ]]; then
-		  context_prefix=""
-		else
-		  context_prefix="$context_name."
+		if [[ ! "$context_name" = 'unspecified' ]]; then
+		  context_config_group="$context_name."
 		fi
 
 		# ignore empty files
@@ -317,8 +316,8 @@ save_helper_scripts() {
 		  if [[ $firstbytes == "U2FsdGVk" ]]; then
 		    cat "$tempfile"
 		  else
-		    cipher=$(git config --get --local transcrypt.${context_prefix}cipher)
-		    password=$(git config --get --local transcrypt.${context_prefix}password)
+		    cipher=$(git config --get --local transcrypt.${context_config_group}cipher)
+		    password=$(git config --get --local transcrypt.${context_config_group}password)
 		    salt=$(openssl dgst -hmac "${filename}:${password}" -sha256 "$filename" | tr -d '\r\n' | tail -c 16)
 		    ENC_PASS=$password openssl enc -$cipher -md MD5 -pass env:ENC_PASS -e -a -S "$salt" -in "$tempfile"
 		  fi
@@ -330,17 +329,16 @@ save_helper_scripts() {
 		filename=$1
 
 		# Look up file's context name from .gitattributes, fall back to no context
+		context_config_group=""
 		context_name=$(git -c core.quotePath=false check-attr crypt-context -- "$filename" | awk 'BEGIN { FS = ": " }; { print $3 }')
-		if [[ $context_name = 'unspecified' ]]; then
-		  context_prefix=""
-		else
-		  context_prefix="$context_name."
+		if [[ ! "$context_name" = 'unspecified' ]]; then
+		  context_config_group="$context_name."
 		fi
 
 		tempfile=$(mktemp 2>/dev/null || mktemp -t tmp)
 		trap 'rm -f "$tempfile"' EXIT
-		cipher=$(git config --get --local transcrypt.${context_prefix}cipher)
-		password=$(git config --get --local transcrypt.${context_prefix}password)
+		cipher=$(git config --get --local transcrypt.${context_config_group}cipher)
+		password=$(git config --get --local transcrypt.${context_config_group}password)
 		tee "$tempfile" | ENC_PASS=$password openssl enc -$cipher -md MD5 -pass env:ENC_PASS -d -a 2>/dev/null || cat "$tempfile"
 	EOF
 
@@ -349,17 +347,16 @@ save_helper_scripts() {
 		filename=$1
 
 		# Look up file's context name from .gitattributes, fall back to no context
+		context_config_group=""
 		context_name=$(git -c core.quotePath=false check-attr crypt-context -- "$filename" | awk 'BEGIN { FS = ": " }; { print $3 }')
-		if [[ $context_name = 'unspecified' ]]; then
-		  context_prefix=""
-		else
-		  context_prefix="$context_name."
+		if [[ ! "$context_name" = 'unspecified' ]]; then
+		  context_config_group="$context_name."
 		fi
 
 		# ignore empty files
 		if [[ -s $filename ]]; then
-		  cipher=$(git config --get --local transcrypt.${context_prefix}cipher)
-		  password=$(git config --get --local transcrypt.${context_prefix}password)
+		  cipher=$(git config --get --local transcrypt.${context_config_group}cipher)
+		  password=$(git config --get --local transcrypt.${context_config_group}password)
 		  ENC_PASS=$password openssl enc -$cipher -md MD5 -pass env:ENC_PASS -d -a -in "$filename" 2>/dev/null || cat "$filename"
 		fi
 	EOF
@@ -690,13 +687,13 @@ uninstall_transcrypt() {
 			touch $encrypted_files
 		fi
 
-		# remove the `git ls-crypt` global alias and context-specific settings
+		# remove the `git ls-crypt` global alias
 		git config --unset alias.ls-crypt
-		for context in $contexts_in_git_config; do
-			# remove context cipher and password settings
-			git config --remove-section transcrypt.${context} 2>/dev/null || true
 
-			# remove context ls-crypt alias variant
+		# remove context settings: cipher & password config, ls-crypt alias variant
+		for context in $contexts_in_git_config; do
+			git config --remove-section transcrypt."${context}" 2>/dev/null || true
+
 			git config --unset alias.ls-crypt-"${context}"
 		done
 
@@ -874,11 +871,11 @@ get_contexts_from_git_config() {
 		if [[ "$name" = "transcrypt.password" ]]; then
 			contexts+=('default')
 		elif [[ $name =~ $extract_context_name_regex ]]; then
-			contexts+=(${BASH_REMATCH[1]})
+			contexts+=("${BASH_REMATCH[1]}")
 		fi
 	done
 	if [ "${contexts:-}" ]; then
-		echo $(trim `printf "%q " "${contexts[@]}"`)
+		trim "$(printf "%q " "${contexts[@]}")"
 	fi
 }
 
@@ -893,13 +890,13 @@ get_contexts_from_git_attributes() {
 	contexts=()
 	for attr_line in $attr_lines; do
 		if [[ $attr_line =~ $extract_context_name_regex ]]; then
-			contexts+=(${BASH_REMATCH[1]})
+			contexts+=("${BASH_REMATCH[1]}")
 		elif [[ $attr_line =~ 'filter=crypt' ]]; then
 			contexts+=('default')
 		fi
 	done
 	if [ "${contexts:-}" ]; then
-		echo $(trim `printf "%q " "${contexts[@]}"`)
+		trim "$(printf "%q " "${contexts[@]}")"
 	fi
 }
 
@@ -908,47 +905,49 @@ get_contexts() {
 	combined_contexts="$(get_contexts_from_git_config) $(get_contexts_from_git_attributes)"
 	sorted_contexts=$(echo "$combined_contexts" | tr ' ' '\n' | sort -u | tr '\n' ' ')
 	if [ "${sorted_contexts:-}" ]; then
-		echo "$(trim $sorted_contexts)"
+		trim "$sorted_contexts"
 	fi
 }
 
 # Echo the number of items in a space-delimited list given as $1
 count_items_in_list() {
-	local trimmed=$(trim $1)
+	local trimmed
+	trimmed=$(trim "$1")
 	if [[ ! "$trimmed" ]]; then
 		return 0
 	fi
 	local just_spaces="${trimmed//[^ ]/}"
-	echo $(( ${#just_spaces} + 1 ))
+	echo $((${#just_spaces} + 1))
 }
 
 # Utility function returns a truthy value if value $1 is in bash list or array $2
 # Based on https://stackoverflow.com/a/8574392/4970
 is_item_in_array() {
-  local e match="$1"
-  shift
-  for e; do [[ "$e" == "$match" ]] && return 0; done
-  return 1
+	local e match="$1"
+	shift
+	for e; do [[ "$e" == "$match" ]] && return 0; done
+	return 1
 }
 
 # Trim leading and trailing whitespace from $1
 # From https://stackoverflow.com/a/3352015/4970
 trim() {
-    local var="$*"
-    # remove leading whitespace characters
-    var="${var#"${var%%[![:space:]]*}"}"
-    # remove trailing whitespace characters
-    var="${var%"${var##*[![:space:]]}"}"
-    printf '%s' "$var"
+	local var="$*"
+	# remove leading whitespace characters
+	var="${var#"${var%%[![:space:]]*}"}"
+	# remove trailing whitespace characters
+	var="${var%"${var##*[![:space:]]}"}"
+	printf '%s' "$var"
 }
 
 list_contexts() {
 	contexts_in_git_config=$(get_contexts_from_git_config)
 	contexts_in_git_attributes=$(get_contexts_from_git_attributes)
 	for context in $(get_contexts); do
-		if ! is_item_in_array "$context" ${contexts_in_git_config[@]}; then
+		# shellcheck disable=SC2086
+		if ! is_item_in_array "$context" ${contexts_in_git_config}; then
 			echo "$context (not initialised)"
-		elif ! is_item_in_array "$context" ${contexts_in_git_attributes[@]}; then
+		elif ! is_item_in_array "$context" ${contexts_in_git_attributes}; then
 			echo "$context (no patterns in .gitattributes)"
 		else
 			echo "$context"
@@ -1064,8 +1063,8 @@ help() {
 		     a file in your repository, the file  will  be  transparently  encrypted
 		     once you stage and commit it:
 
-		         $ echo 'sensitive_file  filter=crypt diff=crypt merge=crypt' \
-				        >> .gitattributes
+		         $ echo 'sensitive_file  filter=crypt diff=crypt merge=crypt' \\
+		            >> .gitattributes
 		         $ git add .gitattributes sensitive_file
 		         $ git commit -m 'Add encrypted version of a sensitive file'
 
@@ -1084,23 +1083,20 @@ help() {
 		     To use multiple passphrases for files with different security contexts,
 		     specify a new  context name  when you initialise  transcrypt or display
 		     credentials. You can list all the contexts configured in the repository
-			 and their status. For example:
+		     and their status. For example:
 
-		         # Initialise a new context "ts" for top-secret files
+		         # Initialise a new context "ts" for top-secret file 'plan'
 		         $ transcrypt --context=ts
 
-		         # Add extra 'crypt-context=ts' attribute in .gitattributes
-		         $ echo \
-				     'ts_file  filter=crypt diff=crypt merge=crypt crypt-context=ts' \
-				     >> .gitattributes
+		         # Add an extra 'crypt-context=ts' attribute in .gitattributes
+		         $ echo 'plan filter=crypt diff=crypt merge=crypt crypt-context=ts'\\
+		            >> .gitattributes
 
-		         $ git add .gitattributes ts_file
-		         $ git commit -m 'Add encrypted version of a top-secret file'
+		         $ git add .gitattributes plan
+		         $ git commit -m 'Add encrypted plan in top-secret context'
 
 		         # List all contexts and their status
 		         $ transcrypt --list-contexts
-		         default (configured, in .gitattributes)
-		         ts (configured, in .gitattributes)
 
 		AUTHOR
 		     Aaron Bull Schaefer <aaron@elasticdog.com>

--- a/transcrypt
+++ b/transcrypt
@@ -1036,15 +1036,14 @@ help() {
 		     -i, --import-gpg=FILE
 		            import the password and cipher from a gpg encrypted file
 
-		     -C, --context=CONTEXT
+		     -C, --context=CONTEXT_NAME
 		            name for a context that can use a different passphrase and cipher
-		            from the "default" context;  use this advanced option, to permit
+		            from the 'default' context;  use this advanced option, to permit
 		            encrypting different files with different passphrases
 
 		     --list-contexts
-		            list all contexts configured in the  repository,  with a warning
-		            message for incompletely configured contexts:
-		            "not initialised" or "no patterns in .gitattributes"
+		            list all contexts configured in the  repository,  and warn about
+		            incompletely configured contexts.
 
 		     -v, --version
 		            print the version information
@@ -1105,6 +1104,9 @@ help() {
 
 		         # List all contexts
 		         $ transcrypt --list-contexts
+
+		         # Display a context's cipher and password
+		         $ transcrypt --context=admin --display
 
 		AUTHOR
 		     Aaron Bull Schaefer <aaron@elasticdog.com>

--- a/transcrypt
+++ b/transcrypt
@@ -756,15 +756,33 @@ upgrade_transcrypt() {
 		fi
 	fi
 
-	# Keep current cipher and password
-	cipher=$(git config --get --local transcrypt.cipher)
-	password=$(git config --get --local transcrypt.password)
-
 	# Keep contents of .gitattributes
 	ORIG_GITATTRIBUTES=$(cat "$GIT_ATTRIBUTES")
 
+	# Keep current cipher and password for each context
+	ORIG_CONFIGS=()
+	for context_name in $CONFIGURED_CONTEXTS; do
+		if [[ "$context_name" = 'default' ]]; then
+			cipher=$(git config --get --local transcrypt.cipher)
+			password=$(git config --get --local transcrypt.password)
+		else
+			cipher=$(git config --get --local transcrypt.${context_name}.cipher)
+			password=$(git config --get --local transcrypt.${context_name}.password)
+		fi
+		ORIG_CONFIGS+=("${context_name}|${cipher}|${password}")
+	done
+
 	uninstall_transcrypt
-	save_configuration
+
+	# Reconfigure cipher and password for each context
+	for orig_config_line in ${ORIG_CONFIGS[@]}; do
+		context=$(echo "$orig_config_line" | awk 'BEGIN { FS = "|" }; { print $1 }')
+		cipher=$(echo "$orig_config_line" | awk 'BEGIN { FS = "|" }; { print $2 }')
+		password=$(echo "$orig_config_line" | awk 'BEGIN { FS = "|" }; { print $3 }')
+
+		set_context_variables # This prepares all the variables needed to save config
+		save_configuration
+	done
 
 	# Re-instate contents of .gitattributes
 	echo "$ORIG_GITATTRIBUTES" >"$GIT_ATTRIBUTES"
@@ -772,10 +790,10 @@ upgrade_transcrypt() {
 	# Update .gitattributes for transcrypt'ed files to include "merge=crypt" config
 	case $OSTYPE in
 	darwin*)
-		/usr/bin/sed -i '' 's/=crypt\(.*\)/=crypt diff=crypt merge=crypt/' "$GIT_ATTRIBUTES"
+		/usr/bin/sed -i '' 's/diff=crypt$/diff=crypt merge=crypt/' "$GIT_ATTRIBUTES"
 		;;
 	linux*)
-		sed -i 's/=crypt\(.*\)/=crypt diff=crypt merge=crypt/' "$GIT_ATTRIBUTES"
+		sed -i 's/diff=crypt$/diff=crypt merge=crypt/' "$GIT_ATTRIBUTES"
 		;;
 	esac
 
@@ -1258,21 +1276,24 @@ while [[ "${1:-}" != '' ]]; do
 done
 
 # Multi-context support, triggered by optional --context / -C command line option
-if [[ $context ]]; then
-	readonly CONTEXT=$context
-	readonly CONTEXT_DESC_SUFFIX=" for context '$CONTEXT'"
-	readonly CONTEXT_TRANSCRYPT_CIPHER=transcrypt.${CONTEXT}.cipher
-	readonly CONTEXT_TRANSCRYPT_PASSWORD=transcrypt.${CONTEXT}.password
-	# For ls-crypt aliases we want one for each context, including 'default'
-	readonly CONTEXT_LS_CRYPT="ls-crypt-$CONTEXT"
-else
-	readonly CONTEXT='default'
-	readonly CONTEXT_DESC_SUFFIX=''
-	readonly CONTEXT_TRANSCRYPT_CIPHER=transcrypt.cipher
-	readonly CONTEXT_TRANSCRYPT_PASSWORD=transcrypt.password
-	# For ls-crypt aliases we want one for each context, including 'default'
-	readonly CONTEXT_LS_CRYPT="ls-crypt-$CONTEXT"
-fi
+set_context_variables() {
+	if [[ "$context" ]] && [[ ! "$context" = 'default' ]]; then
+		CONTEXT=$context
+		CONTEXT_DESC_SUFFIX=" for context '$CONTEXT'"
+		CONTEXT_TRANSCRYPT_CIPHER=transcrypt.${CONTEXT}.cipher
+		CONTEXT_TRANSCRYPT_PASSWORD=transcrypt.${CONTEXT}.password
+		# For ls-crypt aliases we want one for each context, including 'default'
+		CONTEXT_LS_CRYPT="ls-crypt-$CONTEXT"
+	else
+		CONTEXT='default'
+		CONTEXT_DESC_SUFFIX=''
+		CONTEXT_TRANSCRYPT_CIPHER=transcrypt.cipher
+		CONTEXT_TRANSCRYPT_PASSWORD=transcrypt.password
+		# For ls-crypt aliases we want one for each context, including 'default'
+		CONTEXT_LS_CRYPT="ls-crypt-$CONTEXT"
+	fi
+}
+set_context_variables
 
 gather_repo_metadata
 

--- a/transcrypt
+++ b/transcrypt
@@ -643,7 +643,11 @@ uninstall_transcrypt() {
 		printf 'You are about to remove all transcrypt configuration from your repository.\n'
 		printf 'All previously encrypted files will remain decrypted in this working copy, but your\n'
 		printf 'repo will be garbage collected to remove any cached plaintext of secret files.\n\n'
-		printf 'Proceed with uninstall? [y/N] '
+		if [[ $(count_items_in_list "$CONFIGURED_CONTEXTS") -gt "1" ]]; then
+			printf 'Proceed with uninstall of all contexts (%s)? [y/N] ' "$CONFIGURED_CONTEXTS"
+		else
+			printf 'Proceed with uninstall? [y/N] '
+		fi
 		read -r answer
 		printf '\n'
 	else

--- a/transcrypt
+++ b/transcrypt
@@ -939,18 +939,16 @@ trim() {
 }
 
 list_contexts() {
-	in_git_config=$(get_contexts_from_git_config)
-	in_git_attributes=$(get_contexts_from_git_attributes)
+	contexts_in_git_config=$(get_contexts_from_git_config)
+	contexts_in_git_attributes=$(get_contexts_from_git_attributes)
 	for context in $(get_contexts); do
-		config_status='not configured'
-		if is_item_in_array "$context" ${in_git_config[@]}; then
-			config_status='configured'
+		if ! is_item_in_array "$context" ${contexts_in_git_config[@]}; then
+			echo "$context (not initialised)"
+		elif ! is_item_in_array "$context" ${contexts_in_git_attributes[@]}; then
+			echo "$context (no patterns in .gitattributes)"
+		else
+			echo "$context"
 		fi
-		attr_status='not in .gitattributes'
-		if is_item_in_array "$context" ${in_git_attributes[@]}; then
-			attr_status='in .gitattributes'
-		fi
-		echo "$context ($config_status, $attr_status)"
 	done
 }
 
@@ -1036,7 +1034,9 @@ help() {
 		            encrypting different files with different passphrases
 
 		     --list-contexts
-		            list all contexts configured in the repository
+		            list all contexts configured in the  repository,  with a warning
+		            message for incompletely configured contexts:
+		            "not initialised" or "no patterns in .gitattributes"
 
 		     -v, --version
 		            print the version information

--- a/transcrypt
+++ b/transcrypt
@@ -56,8 +56,25 @@ realpath() {
 
 # establish repository metadata and directory handling
 gather_repo_metadata() {
-	# whether or not transcrypt is already configured
-	readonly CONFIGURED=$(git config --get --local "$CONTEXT_TRANSCRYPT_VERSION" 2>/dev/null)
+	contexts_in_git_config=$(get_contexts_from_git_config)
+
+	# whether or not transcrypt is already configured for at least one context
+	if [ -z "${contexts_in_git_config}" ]; then
+		readonly CONFIGURED_FOR_ANY_CONTEXT=''
+	else
+		readonly CONFIGURED_FOR_ANY_CONTEXT=1
+	fi
+
+	# whether or not transcrypt is already configured for the current context
+	if [ $CONFIGURED_FOR_ANY_CONTEXT ]; then
+		first_context_name=$(trim "$contexts_in_git_config" | tr ' ' '\n' | head -1)
+		if [[ "$first_context_name" != 'default' ]]; then
+		  context_prefix="$first_context_name-"
+		else
+		  context_prefix=''
+		fi
+		readonly CONFIGURED_VERSION=$(git config --get --local "transcrypt.${context_prefix}version" 2>/dev/null)
+	fi
 
 	# the current git repository's top-level directory
 	readonly REPO=$(git rev-parse --show-toplevel 2>/dev/null)
@@ -121,11 +138,11 @@ run_safety_checks() {
 
 	# exit if transcrypt is not in the required state
 	if [[ $ignore_config_status ]]; then
-		: # no-op, no need to check $CONFIGURED status
-	elif [[ $requires_existing_config ]] && [[ ! $CONFIGURED ]]; then
-		die 1 "the current repository is not configured$CONTEXT_DESC_SUFFIX"
-	elif [[ ! $requires_existing_config ]] && [[ $CONFIGURED ]]; then
-		die 1 "the current repository is already configured$CONTEXT_DESC_SUFFIX; see --display"
+		: # no-op, no need to check $CONFIGURED_FOR_ANY_CONTEXT status
+	elif [[ $requires_existing_config ]] && [[ ! $CONFIGURED_FOR_ANY_CONTEXT ]]; then
+		die 1 "the current repository is not configured"
+	elif [[ ! $requires_existing_config ]] && [[ $CONFIGURED_FOR_ANY_CONTEXT ]]; then
+		die 1 "the current repository is already configured; see --display"
 	fi
 
 	# check for dependencies
@@ -512,9 +529,9 @@ display_configuration() {
 	local escaped_password=${current_password//\'/\'\\\'\'}
 
 	contexts=$(get_contexts)
-	contexts_array=("$contexts") # Convert list to bash array so we can count elements
+	contexts_count=$(echo $contexts | tr ' ' '\n' | wc -l | tr -d ' ')
 
-	printf 'The current repository was configured using transcrypt version %s\n' "$CONFIGURED"
+	printf 'The current repository was configured using transcrypt version %s\n' "$CONFIGURED_VERSION"
 	printf "and has the following configuration%s:\n\n" "$CONTEXT_DESC_SUFFIX"
 	[[ ! $REPO ]] || printf '  GIT_WORK_TREE:  %s\n' "$REPO"
 	printf '  GIT_DIR:        %s\n' "$GIT_DIR"
@@ -524,8 +541,8 @@ display_configuration() {
 	fi
 	printf '  CIPHER:   %s\n' "$current_cipher"
 	printf '  PASSWORD: %s\n\n' "$current_password"
-	if [[ "${#contexts_array[@]}" -gt "1" ]]; then
-		printf 'The repository has %s contexts: %s\n\n' "${#contexts_array[@]}" "$contexts"
+	if [[ "$contexts_count" -gt "1" ]]; then
+		printf 'The repository has %s contexts: %s\n\n' "$contexts_count" "$contexts"
 	fi
 	printf "Copy and paste the following command to initialize a cloned repository%s:\n\n" "$CONTEXT_DESC_SUFFIX"
 	if [[ $CONTEXT != 'default' ]]; then
@@ -725,12 +742,10 @@ uninstall_transcrypt() {
 
 # uninstall and re-install transcrypt to upgrade scripts and update configuration
 upgrade_transcrypt() {
-	CURRENT_VERSION=$(git config --get --local transcrypt.version 2>/dev/null)
-
 	if [[ $interactive ]]; then
 		printf 'You are about to upgrade the transcrypt scripts in your repository.\n'
 		printf 'Your configuration settings will not be changed.\n\n'
-		printf ' Current version: %s\n' "$CURRENT_VERSION"
+		printf ' Current version: %s\n' "$CONFIGURED_VERSION"
 		printf 'Upgraded version: %s\n\n' "$VERSION"
 		printf 'Proceed with upgrade? [y/N] '
 		read -r answer
@@ -877,7 +892,9 @@ get_contexts_from_git_config() {
 			contexts+=(${BASH_REMATCH[1]})
 		fi
 	done
-	printf "%q " "${contexts[@]:-}"
+	if [ ! -z "${contexts:-}" ]; then
+		printf "%q " "${contexts[@]:-}"
+	fi
 }
 
 # Echo array of context names as defined in the .gitattributes file
@@ -896,15 +913,18 @@ get_contexts_from_git_attributes() {
 			contexts+=(${BASH_REMATCH[1]})
 		fi
 	done
-	printf "%q " "${contexts[@]:-}"
+	if [ ! -z "${contexts:-}" ]; then
+		printf "%q " "${contexts[@]:-}"
+	fi
 }
 
 # Echo all context names, sorted and distinct, as defined in the git config or .gitattributes file
 get_contexts() {
 	combined_contexts="$(get_contexts_from_git_config) $(get_contexts_from_git_attributes)"
 	sorted_contexts=$(echo "$combined_contexts" | tr ' ' '\n' | sort -u | tr '\n' ' ')
-	# Avoid 'unbound variable' if array is empty: https://stackoverflow.com/a/7577209/4970
-	echo ${sorted_contexts[@]+"${sorted_contexts[@]}"}
+	if [ ! -z "${sorted_contexts:-}" ]; then
+		echo "$(trim $sorted_contexts)"
+	fi
 }
 
 # Utility function returns a truthy value if value $1 is in bash array $2
@@ -914,6 +934,17 @@ is_item_in_array() {
   shift
   for e; do [[ "$e" == "$match" ]] && return 0; done
   return 1
+}
+
+# Trim leading and trailing whitespace from $1
+# From https://stackoverflow.com/a/3352015/4970
+trim() {
+    local var="$*"
+    # remove leading whitespace characters
+    var="${var#"${var%%[![:space:]]*}"}"
+    # remove trailing whitespace characters
+    var="${var%"${var##*[![:space:]]}"}"
+    printf '%s' "$var"
 }
 
 list_contexts() {
@@ -1038,7 +1069,8 @@ help() {
 		     a file in your repository, the file  will  be  transparently  encrypted
 		     once you stage and commit it:
 
-		         $ echo 'sensitive_file  filter=crypt diff=crypt merge=crypt' >> .gitattributes
+		         $ echo 'sensitive_file  filter=crypt diff=crypt merge=crypt' \
+				        >> .gitattributes
 		         $ git add .gitattributes sensitive_file
 		         $ git commit -m 'Add encrypted version of a sensitive file'
 
@@ -1059,18 +1091,19 @@ help() {
 		     credentials. You can list all the contexts configured in the repository
 			 and their status. For example:
 
-		         # Initialise a new context "ts" for top-secret files
-		         $ transcrypt --context=ts
+		         # Initialise a new context "TS" for top-secret files
+		         $ transcrypt --context=TS
 
 		         # Use context name as a prefix to 'crypt' in .gitattributes
-		         $ echo 'ts_file  filter=ts-crypt diff=ts-crypt merge=ts-crypt' >> .gitattributes
+		         $ echo 'ts_file  filter=TS-crypt diff=TS-crypt merge=TS-crypt' \
+				        >> .gitattributes
 		         $ git add .gitattributes ts_file
 		         $ git commit -m 'Add encrypted version of a top-secret file'
 
 		         # List all contexts and their status
 		         $ transcrypt --list-contexts
 		         default (configured, in .gitattributes)
-		         ts (configured, in .gitattributes)
+		         TS (configured, in .gitattributes)
 
 		AUTHOR
 		     Aaron Bull Schaefer <aaron@elasticdog.com>
@@ -1108,10 +1141,12 @@ while [[ "${1:-}" != '' ]]; do
 	case $1 in
 	-C | --context)
 		context=$2
+		ignore_config_status='true'
 		shift
 		;;
 	--context=*)
 		context=${1#*=}
+		ignore_config_status='true'
 		;;
 	--list-contexts)
 		list_ctxs='true'

--- a/transcrypt
+++ b/transcrypt
@@ -57,7 +57,10 @@ realpath() {
 # establish repository metadata and directory handling
 gather_repo_metadata() {
 	# whether or not transcrypt is already configured
-	readonly CONFIGURED=$(git config --get --local transcrypt.version 2>/dev/null)
+	readonly INSTALLED_VERSION=$(git config --get --local transcrypt.version 2>/dev/null)
+
+	# fetch list of context names already configured
+	readonly CONFIGURED_CONTEXTS=$(get_contexts_from_git_config)
 
 	# the current git repository's top-level directory
 	readonly REPO=$(git rev-parse --show-toplevel 2>/dev/null)
@@ -124,11 +127,11 @@ run_safety_checks() {
 
 	# exit if transcrypt is not in the required state
 	if [[ $ignore_config_status ]]; then
-		: # no-op, no need to check $CONFIGURED status
-	elif [[ $requires_existing_config ]] && [[ ! $CONFIGURED ]]; then
+		: # no-op, no need to check $CONFIGURED_CONTEXTS status
+	elif [[ $requires_existing_config ]] && [[ ! $CONFIGURED_CONTEXTS ]]; then
 		die 1 'the current repository is not configured'
-	elif [[ ! $requires_existing_config ]] && [[ $CONFIGURED ]]; then
-		die 1 'the current repository is already configured; see --display'
+	elif [[ ! $requires_existing_config ]] && is_item_in_array "$CONTEXT" "$CONFIGURED_CONTEXTS"; then
+		die 1 "the current repository is already configured${CONTEXT_DESC_SUFFIX}; see --display"
 	fi
 
 	# check for dependencies
@@ -454,7 +457,7 @@ save_helper_hooks() {
 
 	# Activate hook by copying it to the pre-commit script name, if safe to do so
 	pre_commit_hook="${RELATIVE_GIT_DIR}/hooks/pre-commit"
-	if [[ -f "$pre_commit_hook" ]] && [[ "$CONFIGURED" ]]; then
+	if [[ -f "$pre_commit_hook" ]] && [[ "$INSTALLED_VERSION" ]]; then
 		: # no-op, skip re-install of pre-commit hook for additional contexts
 	elif [[ -f "$pre_commit_hook" ]]; then
 		printf 'WARNING:\n' >&2
@@ -528,10 +531,9 @@ display_configuration() {
 	current_password=$(git config --get --local "$CONTEXT_TRANSCRYPT_PASSWORD")
 	local escaped_password=${current_password//\'/\'\\\'\'}
 
-	contexts=$(get_contexts_from_git_config)
-	contexts_count="$(count_items_in_list "$contexts")"
+	contexts_count="$(count_items_in_list "$CONFIGURED_CONTEXTS")"
 
-	printf 'The current repository was configured using transcrypt version %s\n' "$CONFIGURED"
+	printf 'The current repository was configured using transcrypt version %s\n' "$INSTALLED_VERSION"
 	printf "and has the following configuration%s:\n\n" "$CONTEXT_DESC_SUFFIX"
 	[[ ! $REPO ]] || printf '  GIT_WORK_TREE:  %s\n' "$REPO"
 	printf '  GIT_DIR:        %s\n' "$GIT_DIR"
@@ -540,7 +542,7 @@ display_configuration() {
 	printf '  CIPHER:   %s\n' "$current_cipher"
 	printf '  PASSWORD: %s\n\n' "$current_password"
 	if [[ "$contexts_count" -gt "1" ]]; then
-		printf 'The repository has %s contexts: %s\n\n' "$contexts_count" "$contexts"
+		printf 'The repository has %s contexts: %s\n\n' "$contexts_count" "$CONFIGURED_CONTEXTS"
 	fi
 	printf "Copy and paste the following command to initialize a cloned repository%s:\n\n" "$CONTEXT_DESC_SUFFIX"
 	if [[ $CONTEXT != 'default' ]]; then
@@ -650,8 +652,6 @@ uninstall_transcrypt() {
 
 	# only uninstall if the user explicitly confirmed
 	if [[ $answer =~ $YES_REGEX ]]; then
-		contexts_in_git_config=$(get_contexts_from_git_config)
-
 		clean_gitconfig
 
 		if [[ ! $upgrade ]]; then
@@ -691,7 +691,7 @@ uninstall_transcrypt() {
 		git config --unset alias.ls-crypt
 
 		# remove context settings: cipher & password config, ls-crypt alias variant
-		for context in $contexts_in_git_config; do
+		for context in $CONFIGURED_CONTEXTS; do
 			git config --remove-section transcrypt."${context}" 2>/dev/null || true
 
 			git config --unset alias.ls-crypt-"${context}"
@@ -727,7 +727,7 @@ upgrade_transcrypt() {
 	if [[ $interactive ]]; then
 		printf 'You are about to upgrade the transcrypt scripts in your repository.\n'
 		printf 'Your configuration settings will not be changed.\n\n'
-		printf ' Current version: %s\n' "$CONFIGURED"
+		printf ' Current version: %s\n' "$INSTALLED_VERSION"
 		printf 'Upgraded version: %s\n\n' "$VERSION"
 		printf 'Proceed with upgrade? [y/N] '
 		read -r answer
@@ -902,7 +902,7 @@ get_contexts_from_git_attributes() {
 
 # Echo all context names, sorted and distinct, from the git config or .gitattributes
 get_contexts() {
-	combined_contexts="$(get_contexts_from_git_config) $(get_contexts_from_git_attributes)"
+	combined_contexts="$CONFIGURED_CONTEXTS $(get_contexts_from_git_attributes)"
 	sorted_contexts=$(echo "$combined_contexts" | tr ' ' '\n' | sort -u | tr '\n' ' ')
 	if [ "${sorted_contexts:-}" ]; then
 		trim "$sorted_contexts"
@@ -941,11 +941,10 @@ trim() {
 }
 
 list_contexts() {
-	contexts_in_git_config=$(get_contexts_from_git_config)
 	contexts_in_git_attributes=$(get_contexts_from_git_attributes)
 	for context in $(get_contexts); do
 		# shellcheck disable=SC2086
-		if ! is_item_in_array "$context" ${contexts_in_git_config}; then
+		if ! is_item_in_array "$context" ${CONFIGURED_CONTEXTS}; then
 			echo "$context (not initialised)"
 		elif ! is_item_in_array "$context" ${contexts_in_git_attributes}; then
 			echo "$context (no patterns in .gitattributes)"

--- a/transcrypt
+++ b/transcrypt
@@ -113,7 +113,7 @@ run_safety_checks() {
 	# validate that we're in a git repository
 	[[ $GIT_DIR ]] || die 'you are not currently in a git repository; did you forget to run "git init"?'
 
-	# Do we have a valid context name?
+	# Check the context name provided (or 'default') is valid
 	full_context_regex="^${CONTEXT_REGEX}$"
 	if [[ ! $CONTEXT =~ $full_context_regex ]]; then
 		warn "context name '${CONTEXT}' is invalid"
@@ -226,9 +226,7 @@ confirm_configuration() {
 	printf '  GIT_DIR:        %s\n' "$GIT_DIR"
 	printf '  GIT_ATTRIBUTES: %s\n\n' "$GIT_ATTRIBUTES"
 	printf 'The following configuration will be saved:\n\n'
-	if [[ $CONTEXT != 'default' ]]; then
-		printf '  CONTEXT:  %s\n' "$CONTEXT"
-	fi
+	printf '  CONTEXT:  %s\n' "$CONTEXT"
 	printf '  CIPHER:   %s\n' "$cipher"
 	printf '  PASSWORD: %s\n\n' "$password"
 	printf 'Does this look correct? [Y/n] '
@@ -252,9 +250,7 @@ confirm_rekey() {
 	printf '  GIT_DIR:        %s\n' "$GIT_DIR"
 	printf '  GIT_ATTRIBUTES: %s\n\n' "$GIT_ATTRIBUTES"
 	printf 'The following configuration will be saved:\n\n'
-	if [[ $CONTEXT != 'default' ]]; then
-		printf '  CONTEXT:  %s\n' "$CONTEXT"
-	fi
+	printf '  CONTEXT:  %s\n' "$CONTEXT"
 	printf '  CIPHER:   %s\n' "$cipher"
 	printf '  PASSWORD: %s\n\n' "$password"
 	printf 'You are about to re-encrypt all encrypted files using new credentials.\n'
@@ -540,9 +536,7 @@ display_configuration() {
 	[[ ! $REPO ]] || printf '  GIT_WORK_TREE:  %s\n' "$REPO"
 	printf '  GIT_DIR:        %s\n' "$GIT_DIR"
 	printf '  GIT_ATTRIBUTES: %s\n\n' "$GIT_ATTRIBUTES"
-	if [[ $CONTEXT != 'default' ]]; then
-		printf '  CONTEXT:  %s\n' "$CONTEXT"
-	fi
+	printf '  CONTEXT:  %s\n' "$CONTEXT"
 	printf '  CIPHER:   %s\n' "$current_cipher"
 	printf '  PASSWORD: %s\n\n' "$current_password"
 	if [[ "$contexts_count" -gt "1" ]]; then

--- a/transcrypt
+++ b/transcrypt
@@ -21,8 +21,8 @@ readonly VERSION='2.0.0'
 # the default cipher to utilize
 readonly DEFAULT_CIPHER='aes-256-cbc'
 
-# regular expression used to ensure context name is safe for use in git config
-readonly CONTEXT_REGEX='[a-z][a-z0-9-]*'
+# context name must match this regexp to ensure it is safe for git config and attrs
+readonly CONTEXT_REGEX='[a-z](-?[a-z0-9])*'
 
 ##### FUNCTIONS
 
@@ -116,7 +116,10 @@ run_safety_checks() {
 	# Do we have a valid context name?
 	full_context_regex="^${CONTEXT_REGEX}$"
 	if [[ ! $CONTEXT =~ $full_context_regex ]]; then
-		die 1 "context name '$CONTEXT' is invalid, must be lowercase ASCII letter followed by zero or more of letter/number/hyphen"
+		warn "context name '${CONTEXT}' is invalid"
+		echo "Must be lowercase ASCII starting with a letter then zero or more letters or numbers, hyphen seperator permitted"
+		echo "Examples: x  prod  shh  admins-only  top-secret  abc-123-xyz"
+		exit 1
 	fi
 
 	# exit if transcrypt is not in the required state

--- a/transcrypt
+++ b/transcrypt
@@ -56,25 +56,8 @@ realpath() {
 
 # establish repository metadata and directory handling
 gather_repo_metadata() {
-	contexts_in_git_config=$(get_contexts_from_git_config)
-
-	# whether or not transcrypt is already configured for at least one context
-	if [ -z "${contexts_in_git_config}" ]; then
-		readonly CONFIGURED_FOR_ANY_CONTEXT=''
-	else
-		readonly CONFIGURED_FOR_ANY_CONTEXT=1
-	fi
-
-	# whether or not transcrypt is already configured for the current context
-	if [ $CONFIGURED_FOR_ANY_CONTEXT ]; then
-		first_context_name=$(trim "$contexts_in_git_config" | tr ' ' '\n' | head -1)
-		if [[ "$first_context_name" != 'default' ]]; then
-		  context_prefix="$first_context_name-"
-		else
-		  context_prefix=''
-		fi
-		readonly CONFIGURED_VERSION=$(git config --get --local "transcrypt.${context_prefix}version" 2>/dev/null)
-	fi
+	# whether or not transcrypt is already configured
+	readonly CONFIGURED=$(git config --get --local transcrypt.version 2>/dev/null)
 
 	# the current git repository's top-level directory
 	readonly REPO=$(git rev-parse --show-toplevel 2>/dev/null)
@@ -138,11 +121,11 @@ run_safety_checks() {
 
 	# exit if transcrypt is not in the required state
 	if [[ $ignore_config_status ]]; then
-		: # no-op, no need to check $CONFIGURED_FOR_ANY_CONTEXT status
-	elif [[ $requires_existing_config ]] && [[ ! $CONFIGURED_FOR_ANY_CONTEXT ]]; then
-		die 1 "the current repository is not configured"
-	elif [[ ! $requires_existing_config ]] && [[ $CONFIGURED_FOR_ANY_CONTEXT ]]; then
-		die 1 "the current repository is already configured; see --display"
+		: # no-op, no need to check $CONFIGURED status
+	elif [[ $requires_existing_config ]] && [[ ! $CONFIGURED ]]; then
+		die 1 'the current repository is not configured'
+	elif [[ ! $requires_existing_config ]] && [[ $CONFIGURED ]]; then
+		die 1 'the current repository is already configured; see --display'
 	fi
 
 	# check for dependencies
@@ -462,7 +445,7 @@ save_helper_hooks() {
 
 	# Activate hook by copying it to the pre-commit script name, if safe to do so
 	pre_commit_hook="${RELATIVE_GIT_DIR}/hooks/pre-commit"
-	if [[ -f "$pre_commit_hook" && "$CONTEXT" != "default" ]]; then
+	if [[ -f "$pre_commit_hook" ]] && [[ "$CONFIGURED" ]]; then
 		: # no-op, skip re-install of pre-commit hook for additional contexts
 	elif [[ -f "$pre_commit_hook" ]]; then
 		printf 'WARNING:\n' >&2
@@ -481,7 +464,7 @@ save_configuration() {
 	save_helper_hooks
 
 	# write the encryption info
-	git config "$CONTEXT_TRANSCRYPT_VERSION" "$VERSION"
+	git config "transcrypt.version" "$VERSION"
 	git config "$CONTEXT_TRANSCRYPT_CIPHER" "$cipher"
 	git config "$CONTEXT_TRANSCRYPT_PASSWORD" "$password"
 
@@ -531,7 +514,7 @@ display_configuration() {
 	contexts=$(get_contexts)
 	contexts_count=$(echo $contexts | tr ' ' '\n' | wc -l | tr -d ' ')
 
-	printf 'The current repository was configured using transcrypt version %s\n' "$CONFIGURED_VERSION"
+	printf 'The current repository was configured using transcrypt version %s\n' "$CONFIGURED"
 	printf "and has the following configuration%s:\n\n" "$CONTEXT_DESC_SUFFIX"
 	[[ ! $REPO ]] || printf '  GIT_WORK_TREE:  %s\n' "$REPO"
 	printf '  GIT_DIR:        %s\n' "$GIT_DIR"
@@ -745,7 +728,7 @@ upgrade_transcrypt() {
 	if [[ $interactive ]]; then
 		printf 'You are about to upgrade the transcrypt scripts in your repository.\n'
 		printf 'Your configuration settings will not be changed.\n\n'
-		printf ' Current version: %s\n' "$CONFIGURED_VERSION"
+		printf ' Current version: %s\n' "$CONFIGURED"
 		printf 'Upgraded version: %s\n\n' "$VERSION"
 		printf 'Proceed with upgrade? [y/N] '
 		read -r answer
@@ -882,11 +865,11 @@ import_gpg() {
 
 # Echo array of context names as defined in the git config
 get_contexts_from_git_config() {
+	config_names=$(git config --local --name-only --list | grep transcrypt)
+	extract_context_name_regex="transcrypt\.(${CONTEXT_REGEX})-password"
 	contexts=()
-	config_names=$(git config --local --name-only --list)
-	extract_context_name_regex="transcrypt\.(${CONTEXT_REGEX})-version"
 	for name in $config_names; do
-		if [[ $name =~ transcrypt\.version ]]; then
+		if [[ "$name" = "transcrypt.password" ]]; then
 			contexts+=('default')
 		elif [[ $name =~ $extract_context_name_regex ]]; then
 			contexts+=(${BASH_REMATCH[1]})
@@ -1254,7 +1237,6 @@ done
 if [[ $context ]]; then
 	readonly CONTEXT=$context
 	readonly CONTEXT_DESC_SUFFIX=" for context '$CONTEXT'"
-	readonly CONTEXT_TRANSCRYPT_VERSION=transcrypt.${CONTEXT}-version
 	readonly CONTEXT_TRANSCRYPT_CIPHER=transcrypt.${CONTEXT}-cipher
 	readonly CONTEXT_TRANSCRYPT_PASSWORD=transcrypt.${CONTEXT}-password
 	readonly CONTEXT_CRYPT=${CONTEXT}-crypt
@@ -1263,7 +1245,6 @@ if [[ $context ]]; then
 else
 	readonly CONTEXT='default'
 	readonly CONTEXT_DESC_SUFFIX=''
-	readonly CONTEXT_TRANSCRYPT_VERSION=transcrypt.version
 	readonly CONTEXT_TRANSCRYPT_CIPHER=transcrypt.cipher
 	readonly CONTEXT_TRANSCRYPT_PASSWORD=transcrypt.password
 	readonly CONTEXT_CRYPT=crypt

--- a/transcrypt
+++ b/transcrypt
@@ -771,8 +771,8 @@ upgrade_transcrypt() {
 			cipher=$(git config --get --local transcrypt.cipher)
 			password=$(git config --get --local transcrypt.password)
 		else
-			cipher=$(git config --get --local transcrypt.${context_name}.cipher)
-			password=$(git config --get --local transcrypt.${context_name}.password)
+			cipher=$(git config --get --local transcrypt."${context_name}".cipher)
+			password=$(git config --get --local transcrypt."${context_name}".password)
 		fi
 		ORIG_CONFIGS+=("${context_name}|${cipher}|${password}")
 	done
@@ -780,7 +780,7 @@ upgrade_transcrypt() {
 	uninstall_transcrypt
 
 	# Reconfigure cipher and password for each context
-	for orig_config_line in ${ORIG_CONFIGS[@]}; do
+	for orig_config_line in "${ORIG_CONFIGS[@]}"; do
 		context=$(echo "$orig_config_line" | awk 'BEGIN { FS = "|" }; { print $1 }')
 		cipher=$(echo "$orig_config_line" | awk 'BEGIN { FS = "|" }; { print $2 }')
 		password=$(echo "$orig_config_line" | awk 'BEGIN { FS = "|" }; { print $3 }')

--- a/transcrypt
+++ b/transcrypt
@@ -471,7 +471,9 @@ save_helper_hooks() {
 save_configuration() {
 	# prevent clobbering existing configuration
 	# shellcheck disable=SC2086
-	if is_item_in_array "$CONTEXT" ${CONFIGURED_CONTEXTS}; then
+	if [[ $upgrade ]]; then
+		: # Bypass safety check on upgrade; we know we just called uninstall_transcrypt
+	elif is_item_in_array "$CONTEXT" ${CONFIGURED_CONTEXTS}; then
 		if [[ "$CONTEXT" = 'default' ]]; then
 			die 1 "the current repository is already configured; see 'transcrypt --display'"
 		else


### PR DESCRIPTION
Hi, thanks for your great work on *transcrypt*! We have found it really useful.

We are considering using *transcrypt* for a scenario it wasn't designed for, where we want to have multiple "contexts" of secret file within the one repository with a different passphrase for each one. 
Basically, we have some files in a repo that should be encrypted but available to user group A, and another set of files that should only be available to user group B. 

This PR contains a **very** rough but working proof of concept with *transcrypt* updated to support this use case, where different security "contexts" can be specified by setting a `CONTEXT` environment variable before running the script.

**If you are at all interested in adding such a feature please let me know here, along with any thoughts about how you would prefer it to be built.** We can work on improving the implementation if you think it might get included in the official version later?

The implementation here so far is a quick and dirty hack that duplicates all the git hook scripts for each named context, so that each one knows about its particular settings.

Despite being an awful hack it shows that the process works fairly well, with just those files for which the user has set the appropriate context & passphrase decrypted, and the rest left as they were.

Example usage:

- Choose a name for a non-default encryption "context" e.g. "super-secret"
- Init transcrypt in default and "super-secret" contexts:
  ```bash
  $ transcrypt
  # follow prompts

  $ CONTEXT=-super-secret transcrypt
  # follow prompts, note leading dash (-)
  ```
- Set patterns in `.gitattributes` as usual for default decryption, and with the suffix "-super-secret" for that additional context:
    ```
    # Contents of .gitattributes
    secret.txt filter=crypt diff=crypt
    super-secret.txt filter=crypt-super-secret diff=crypt-super-secret
    ```
- Write your secret files, `git add` them, and commit.
- Note the different passphrases for default and additional contexts
  ```bash
  $ transcrypt --display

  $ CONTEXT=-super-secret transcrypt --display
  ```
- Clone repo elsewhere, and confirm that you can or cannot see file contents as you apply some combination of the init commands as printed by the display commands above.
