### PR TITLE
Add Git pre-commit hook to abort commit with unencrypted files (#31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ complexity here would be worth it given transcrypt's use case.
 transcrypt is provided under the terms of the
 [MIT License](https://en.wikipedia.org/wiki/MIT_License).
 
-Copyright &copy; 2014-2019, [Aaron Bull Schaefer](mailto:aaron@elasticdog.com).
+Copyright &copy; 2014-2020, [Aaron Bull Schaefer](mailto:aaron@elasticdog.com).
 
 ## Contributing
 
@@ -308,3 +308,14 @@ To run the tests:
 - [install bats-core](https://github.com/bats-core/bats-core#installation)
 - run all tests with: `bats tests/`
 - run an individual test with e.g: `./tests/test_help.bats`
+
+## Changes
+
+Improvements:
+
+- Add Git pre-commit hook to reject commit of file that should be encrypted but
+  has plain text content: a safety mechanism to prevent accidental commits of
+  plain text files staged by tools that do not respect the .gitattribute
+  filters Transcrypt needs to do its job.
+
+- Add functional tests.

--- a/tests/_test_helper.bash
+++ b/tests/_test_helper.bash
@@ -32,3 +32,31 @@ function cleanup_all {
   rm $BATS_TEST_DIRNAME/.gitattributes
   rm $BATS_TEST_DIRNAME/sensitive_file
 }
+
+function init_transcrypt {
+  $BATS_TEST_DIRNAME/../transcrypt --cipher=aes-256-cbc --password=abc123 --yes
+}
+
+function encrypt_named_file {
+  filename=$1
+  content=$2
+  if [ "$content" ]; then
+    echo "$content" > $filename
+  fi
+  echo "$filename filter=crypt diff=crypt" >> .gitattributes
+  git add .gitattributes $filename
+  git commit -m "Encrypt file $filename"
+}
+
+function setup {
+  pushd $BATS_TEST_DIRNAME
+  init_git_repo
+  if [ ! "$SETUP_SKIP_INIT_TRANSCRYPT" ]; then
+    init_transcrypt
+  fi
+}
+
+function teardown {
+  cleanup_all
+  popd
+}

--- a/tests/test_crypt.bats
+++ b/tests/test_crypt.bats
@@ -5,84 +5,61 @@ load $BATS_TEST_DIRNAME/_test_helper.bash
 SECRET_CONTENT="My secret content"
 SECRET_CONTENT_ENC="U2FsdGVkX1/kkWK36bn3fbq5DY2d+JXL2YWoN/eoXA1XJZEk9JS7j/856rXK9gPn"
 
-function init_transcrypt {
-  $BATS_TEST_DIRNAME/../transcrypt --cipher=aes-256-cbc --password=abc123 --yes
-}
-
-function encrypt_file {
-  echo $SECRET_CONTENT > sensitive_file
-  echo 'sensitive_file filter=crypt diff=crypt' >> .gitattributes
-  git add .gitattributes sensitive_file
-  git commit -m 'Add encrypted version of a sensitive file'
-}
-
 function check_repo_is_clean {
   git diff-index --quiet HEAD --
 }
 
-
-function setup {
-  pushd $BATS_TEST_DIRNAME
-  init_git_repo
-  init_transcrypt
-}
-
-function teardown {
-  cleanup_all
-  popd
-}
-
-@test "git ls-crypt command is available" {
+@test "crypt: git ls-crypt command is available" {
   # No encrypted file yet, so command should work with no output
   run git ls-crypt
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = "" ]
 }
 
-@test "encrypt a file" {
-  encrypt_file
+@test "crypt: encrypt a file" {
+  encrypt_named_file sensitive_file "$SECRET_CONTENT"
 }
 
-@test "encrypted file contents are decrypted in working copy" {
-  encrypt_file
+@test "crypt: encrypted file contents are decrypted in working copy" {
+  encrypt_named_file sensitive_file "$SECRET_CONTENT"
   run cat sensitive_file
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = "$SECRET_CONTENT" ]
 }
 
-@test "encrypted file contents are encrypted in git (via git show)" {
-  encrypt_file
+@test "crypt: encrypted file contents are encrypted in git (via git show)" {
+  encrypt_named_file sensitive_file "$SECRET_CONTENT"
   run git show HEAD:sensitive_file --no-textconv
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = "$SECRET_CONTENT_ENC" ]
 }
 
-@test "transcrypt --show-raw shows encrypted content" {
-  encrypt_file
+@test "crypt: transcrypt --show-raw shows encrypted content" {
+  encrypt_named_file sensitive_file "$SECRET_CONTENT"
   run ../transcrypt --show-raw sensitive_file
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = "==> sensitive_file <==" ]
   [ "${lines[1]}" = "$SECRET_CONTENT_ENC" ]
 }
 
-@test "git ls-crypt lists encrypted file" {
-  encrypt_file
+@test "crypt: git ls-crypt lists encrypted file" {
+  encrypt_named_file sensitive_file "$SECRET_CONTENT"
 
   run git ls-crypt
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = "sensitive_file" ]
 }
 
-@test "transcrypt --list lists encrypted file" {
-  encrypt_file
+@test "crypt: transcrypt --list lists encrypted file" {
+  encrypt_named_file sensitive_file "$SECRET_CONTENT"
 
   run ../transcrypt --list
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = "sensitive_file" ]
 }
 
-@test "transcrypt --uninstall leaves decrypted file and repo dirty" {
-  encrypt_file
+@test "crypt: transcrypt --uninstall leaves decrypted file and repo dirty" {
+  encrypt_named_file sensitive_file "$SECRET_CONTENT"
 
   run ../transcrypt --uninstall --yes
   [ "$status" -eq 0 ]
@@ -98,8 +75,8 @@ function teardown {
   [ "$status" -ne 0 ]
 }
 
-@test "git reset after uninstall leaves encrypted file" {
-  encrypt_file
+@test "crypt: git reset after uninstall leaves encrypted file" {
+  encrypt_named_file sensitive_file "$SECRET_CONTENT"
 
   ../transcrypt --uninstall --yes
 

--- a/tests/test_init.bats
+++ b/tests/test_init.bats
@@ -2,19 +2,9 @@
 
 load $BATS_TEST_DIRNAME/_test_helper.bash
 
-function init_transcrypt {
-  $BATS_TEST_DIRNAME/../transcrypt --cipher=aes-256-cbc --password=abc123 --yes
-}
+# Custom setup: don't init transcrypt
+SETUP_SKIP_INIT_TRANSCRYPT=1
 
-function setup {
-  pushd $BATS_TEST_DIRNAME
-  init_git_repo
-}
-
-function teardown {
-  cleanup_all
-  popd
-}
 
 @test "init: works at all" {
   # Use literal command not function to confirm command works at least once

--- a/tests/test_not_inited.bats
+++ b/tests/test_not_inited.bats
@@ -2,17 +2,11 @@
 
 load $BATS_TEST_DIRNAME/_test_helper.bash
 
-function setup {
-  pushd $BATS_TEST_DIRNAME
-  # Need to init and tear down Git repo for these tests, mainly to avoid falling
-  # back to the transcrypt repo's Git config and partial transcrypt setup
-  init_git_repo
-}
+# Custom setup: don't init transcrypt
+# We need to init and tear down Git repo for these tests, mainly to avoid
+# falling back to the transcrypt repo's Git config and partial transcrypt setup
+SETUP_SKIP_INIT_TRANSCRYPT=1
 
-function teardown {
-  nuke_git_repo
-  popd
-}
 
 # Operations that should work in a repo not yet initialised
 

--- a/tests/test_pre_commit.bats
+++ b/tests/test_pre_commit.bats
@@ -1,0 +1,111 @@
+#!/usr/bin/env bats
+
+load $BATS_TEST_DIRNAME/_test_helper.bash
+
+function init_transcrypt {
+  $BATS_TEST_DIRNAME/../transcrypt --cipher=aes-256-cbc --password=abc123 --yes
+}
+
+function encrypt_named_file {
+  filename=$1
+  echo "$filename filter=crypt diff=crypt merge=crypt" >> .gitattributes
+  git add .gitattributes $filename
+  git commit -m "Encrypt file $filename"
+}
+
+function setup {
+  pushd $BATS_TEST_DIRNAME
+  init_git_repo
+  init_transcrypt
+}
+
+function teardown {
+  cleanup_all
+  popd
+}
+
+@test "pre-commit: pre-commit hook installed on init" {
+  # Confirm pre-commit-crypt file is installed
+  [ -f .git/hooks/pre-commit-crypt ]
+  run cat .git/hooks/pre-commit-crypt
+  [ "${lines[1]}" = '# Transcrypt pre-commit hook: fail if secret file in staging lacks the magic prefix "Salted" in B64' ]
+
+  # Confirm hook is also installed/activated at pre-commit file name
+  [ -f .git/hooks/pre-commit ]
+  run cat .git/hooks/pre-commit
+  [ "${lines[1]}" = '# Transcrypt pre-commit hook: fail if secret file in staging lacks the magic prefix "Salted" in B64' ]
+}
+
+@test "pre-commit: permit commit of encrypted file with encrypted content" {
+  echo "Secret stuff" > sensitive_file
+  encrypt_named_file sensitive_file
+
+  echo " and more secrets" >> sensitive_file
+  git add sensitive_file
+  run git commit -m "Added more"
+  [ "$status" -eq 0 ]
+
+  run git log --format=oneline
+  [ "$status" -eq 0 ]
+  [[ "${lines[0]}" = *"Added more" ]]
+  [[ "${lines[1]}" = *"Encrypt file sensitive_file" ]]
+}
+
+@test "pre-commit: reject commit of encrypted file with unencrypted content" {
+  echo "Secret stuff" > sensitive_file
+  encrypt_named_file sensitive_file
+
+  echo " and more secrets" >> sensitive_file
+
+  # Disable file's crypt config in .gitattributes, add change, then re-enable
+  echo "" > .gitattributes
+  git add sensitive_file
+  echo "sensitive_file filter=crypt diff=crypt merge=crypt" > .gitattributes
+
+  # Confirm the pre-commit rejects plain text content in what should be
+  # an encrypted file
+  run git commit -m "Added more"
+  [ "$status" -ne 0 ]
+  [ "${lines[0]}" = "Transcrypt managed file is not encrypted in the Git index: sensitive_file" ]
+  [ "${lines[1]}" = "You probably staged this file using a tool that does not apply .gitattribute filters as required by Transcrypt." ]
+  [ "${lines[2]}" = "Fix this by re-staging the file with a compatible tool or with Git on the command line:" ]
+  [ "${lines[3]}" = "    git reset -- sensitive_file" ]
+  [ "${lines[4]}" = "    git add sensitive_file" ]
+}
+
+@test "pre-commit: warn and don't clobber existing pre-commit hook on init" {
+  # Uninstall pre-existing transcrypt config from setup()
+  run $BATS_TEST_DIRNAME/../transcrypt --uninstall --yes
+
+  # Create a pre-existing pre-commit hook
+  touch .git/hooks/pre-commit
+
+  run $BATS_TEST_DIRNAME/../transcrypt --cipher=aes-256-cbc --password=abc123 --yes
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "WARNING:" ]
+  [ "${lines[1]}" = "Cannot install Git pre-commit hook script because file already exists: .git/hooks/pre-commit" ]
+  [ "${lines[2]}" = "Please manually install the pre-commit script saved as: .git/hooks/pre-commit-crypt" ]
+
+  # Confirm pre-commit-crypt file is installed, but not copied to pre-commit
+  run cat .git/hooks/pre-commit-crypt
+  [ "$status" -eq 0 ]
+  [ "${lines[1]}" = '# Transcrypt pre-commit hook: fail if secret file in staging lacks the magic prefix "Salted" in B64' ]
+  [ ! -s .git/hooks/pre-commit ] # Zero file size
+}
+
+@test "pre-commit: de-activate and remove transcrypt's pre-commit hook" {
+  $BATS_TEST_DIRNAME/../transcrypt --uninstall --yes
+  [ ! -f .git/hooks/pre-commit ]
+  [ ! -f .git/hooks/pre-commit-crypt ]
+}
+
+@test "pre-commit: warn and don't delete customised pre-commit hook on uninstall" {
+  # Customise transcrypt's pre-commit hook
+  echo "#" >> .git/hooks/pre-commit
+
+  run $BATS_TEST_DIRNAME/../transcrypt --uninstall --yes
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = 'WARNING: Cannot safely disable Git pre-commit hook .git/hooks/pre-commit please check it yourself' ]
+  [ -f .git/hooks/pre-commit ]
+  [ ! -f .git/hooks/pre-commit-crypt ]
+}

--- a/tests/test_pre_commit.bats
+++ b/tests/test_pre_commit.bats
@@ -2,28 +2,6 @@
 
 load $BATS_TEST_DIRNAME/_test_helper.bash
 
-function init_transcrypt {
-  $BATS_TEST_DIRNAME/../transcrypt --cipher=aes-256-cbc --password=abc123 --yes
-}
-
-function encrypt_named_file {
-  filename=$1
-  echo "$filename filter=crypt diff=crypt merge=crypt" >> .gitattributes
-  git add .gitattributes $filename
-  git commit -m "Encrypt file $filename"
-}
-
-function setup {
-  pushd $BATS_TEST_DIRNAME
-  init_git_repo
-  init_transcrypt
-}
-
-function teardown {
-  cleanup_all
-  popd
-}
-
 @test "pre-commit: pre-commit hook installed on init" {
   # Confirm pre-commit-crypt file is installed
   [ -f .git/hooks/pre-commit-crypt ]

--- a/transcrypt
+++ b/transcrypt
@@ -70,8 +70,7 @@ gather_repo_metadata() {
 	readonly IS_BARE=$(git rev-parse --is-bare-repository 2>/dev/null || printf 'false')
 
 	# the current git repository's .git directory
-	local RELATIVE_GIT_DIR
-	RELATIVE_GIT_DIR=$(git rev-parse --git-dir 2>/dev/null || printf '')
+	readonly RELATIVE_GIT_DIR=$(git rev-parse --git-dir 2>/dev/null || printf '')
 	readonly GIT_DIR=$(realpath "$RELATIVE_GIT_DIR" 2>/dev/null)
 
 	# the current git repository's gitattributes file
@@ -113,7 +112,7 @@ run_safety_checks() {
 
 	# exit if transcrypt is not in the required state
 	if [[ $ignore_config_status ]]; then
-		:  # no-op, no need to check $CONFIGURED status
+		: # no-op, no need to check $CONFIGURED status
 	elif [[ $requires_existing_config ]] && [[ ! $CONFIGURED ]]; then
 		die 1 'the current repository is not configured'
 	elif [[ ! $requires_existing_config ]] && [[ $CONFIGURED ]]; then
@@ -122,7 +121,7 @@ run_safety_checks() {
 
 	# check for dependencies
 	for cmd in {column,grep,mktemp,openssl,sed,tee}; do
-		command -v $cmd >/dev/null || die 'required command "%s" was not found' "$cmd"
+		command -v "$cmd" >/dev/null || die 'required command "%s" was not found' "$cmd"
 	done
 
 	# ensure the repository is clean (if it has a HEAD revision) so we can force
@@ -329,9 +328,54 @@ save_helper_scripts() {
 	done
 }
 
+# save helper hooks under the repository's git directory
+save_helper_hooks() {
+	# Install pre-commit-crypt hook script
+	pre_commit_hook_installed="${RELATIVE_GIT_DIR}/hooks/pre-commit-crypt"
+	cat <<-'EOF' >"$pre_commit_hook_installed"
+		#!/usr/bin/env bash
+		# Transcrypt pre-commit hook: fail if secret file in staging lacks the magic prefix "Salted" in B64
+		for secret_file in $(git ls-files | git check-attr --stdin filter | awk 'BEGIN { FS = ":" }; /crypt$/{ print $1 }'); do
+		  # Get prefix of raw file in Git's index using the :FILENAME revision syntax
+		  firstbytes=$(git show :$secret_file | head -c 8)
+		  # An empty file does not need to be, and is not, encrypted
+		  if [[ $firstbytes == "" ]]; then
+		    :  # Do nothing
+		  # The first bytes of an encrypted file must be "Salted" in Base64
+		  elif [[ $firstbytes != "U2FsdGVk" ]]; then
+		    printf 'Transcrypt managed file is not encrypted in the Git index: %s\n' $secret_file >&2
+		    printf '\n' >&2
+		    printf 'You probably staged this file using a tool that does not apply' >&2
+		    printf ' .gitattribute filters as required by Transcrypt.\n' >&2
+		    printf '\n' >&2
+		    printf 'Fix this by re-staging the file with a compatible tool or with'
+		    printf ' Git on the command line:\n' >&2
+		    printf '\n' >&2
+		    printf '    git reset -- %s\n' $secret_file >&2
+		    printf '    git add %s\n' $secret_file >&2
+		    printf '\n' >&2
+		    exit 1
+		  fi
+		done
+	EOF
+
+	# Activate hook by copying it to the pre-commit script name, if safe to do so
+	pre_commit_hook="${RELATIVE_GIT_DIR}/hooks/pre-commit"
+	if [[ -f "$pre_commit_hook" ]]; then
+		printf 'WARNING:\n' >&2
+		printf 'Cannot install Git pre-commit hook script because file already exists: %s\n' "$pre_commit_hook" >&2
+		printf 'Please manually install the pre-commit script saved as: %s\n' "$pre_commit_hook_installed" >&2
+		printf '\n'
+	else
+		cp "$pre_commit_hook_installed" "$pre_commit_hook"
+		chmod 0755 "$pre_commit_hook"
+	fi
+}
+
 # write the configuration to the repository's git config
 save_configuration() {
 	save_helper_scripts
+	save_helper_hooks
 
 	# write the encryption info
 	git config transcrypt.version "$VERSION"
@@ -472,6 +516,20 @@ uninstall_transcrypt() {
 			[[ ! -f "${GIT_DIR}/crypt/${script}" ]] || rm "${GIT_DIR}/crypt/${script}"
 		done
 		[[ ! -d "${GIT_DIR}/crypt" ]] || rmdir "${GIT_DIR}/crypt"
+
+		# rename helper hooks (don't delete, in case user has custom changes)
+		pre_commit_hook="${RELATIVE_GIT_DIR}/hooks/pre-commit"
+		pre_commit_hook_installed="${RELATIVE_GIT_DIR}/hooks/pre-commit-crypt"
+		if [ -f "$pre_commit_hook" ]; then
+			hook_md5=$(openssl md5 -hex <"$pre_commit_hook")
+			installed_md5=$(openssl md5 -hex <"$pre_commit_hook_installed")
+			if [[ "$hook_md5" = "$installed_md5" ]]; then
+				rm "$pre_commit_hook"
+			else
+				printf 'WARNING: Cannot safely disable Git pre-commit hook %s please check it yourself\n' "$pre_commit_hook"
+			fi
+		fi
+		[[ -f "$pre_commit_hook_installed" ]] && rm "$pre_commit_hook_installed"
 
 		# touch all encrypted files to prevent stale stat info
 		local encrypted_files
@@ -729,7 +787,7 @@ uninstall=''
 # used to bypass certain safety checks
 requires_existing_config=''
 requires_clean_repo='true'
-ignore_config_status=''  # Set for operations where config can exist or not
+ignore_config_status='' # Set for operations where config can exist or not
 
 # parse command line options
 while [[ "${1:-}" != '' ]]; do


### PR DESCRIPTION
On init, add a pre-commit Git hook script to check Transcrypt-managed files and abort a commit if there is an un-encrypted file staged in the index that would otherwise be committed in plaintext. See related issue #31

This is a safety mechanism to prevent accidental commits of plain text files that have been staged by tools that do not respect or run the *.gitattribute* filters that Transcrypt needs to do its job.

On commit failure, the error message says how to re-stage the file using Git on the command line:

    Transcrypt managed file is not encrypted in the Git index: secret_file

    You probably staged this file using a tool that does not apply .gitattribute filters as required by Transcrypt.

    Fix this by re-staging the file with a compatible tool or with Git on the command line:

        git reset -- secret_file
        git add secret_file

Because Git hooks work with single scripts only it is difficult to cleanly install and uninstall hook scripts, especially if the user already has a pre-commit hook script in place.

To handle this situation cleanly if naively

- always install a *pre-commit-crypt* copy of the hook script, which isn't active because it doesn't have the *pre-commit* file name
- on init, check if the user already has a *pre-commit* script and instead of clobbering it, print a warning telling the user to manually install the script from *pre-commit-crypt*
- on uninstall, only delete the *pre-commit* if it exactly matches *pre-commit-crypt* file, which would indicate the user had manually edited the *pre-commit* file.