### PR TITLE
Improve merge driver script to work for complex merges

### DIFF
--- a/tests/test_merge.bats
+++ b/tests/test_merge.bats
@@ -31,7 +31,8 @@ load $BATS_TEST_DIRNAME/_test_helper.bash
   git commit -m "Add line 2, change line 1"
 
   git checkout -
-  git merge branch-2
+  run git merge branch-2
+  [ "$status" -eq 0 ]
 
   run cat sensitive_file
   [ "$status" -eq 0 ]

--- a/transcrypt
+++ b/transcrypt
@@ -338,32 +338,34 @@ save_helper_scripts() {
 		  THEIRS_LABEL="theirs"
 		fi
 
-		# Decrypt BASE, LOCAL, and REMOTE versions of file being merged
-		echo "$(cat $1 | ./.git/crypt/smudge)" > $1
-		echo "$(cat $2 | ./.git/crypt/smudge)" > $2
-		echo "$(cat $3 | ./.git/crypt/smudge)" > $3
+		# Decrypt BASE $1, LOCAL $2, and REMOTE $3 versions of file being merged
+		echo "$(cat "$1" | ./.git/crypt/smudge)" > "$1"
+		echo "$(cat "$2" | ./.git/crypt/smudge)" > "$2"
+		echo "$(cat "$3" | ./.git/crypt/smudge)" > "$3"
 
-		# Merge the decrypted files to the working copy named by $5
-		# We must redirect stdout to $5 here instead of letting merge-file write to
-		# $2 as it would by default, because we need $5 to contain the final result
-		# content so a later crypt `clean` generates the correct hash salt value
-		git merge-file --stdout --marker-size=$4 -L $OURS_LABEL -L base -L $THEIRS_LABEL $2 $1 $3 > $5
+		# Merge the decrypted files to the temp file named by $2
+		git merge-file --marker-size=$4 -L "$OURS_LABEL" -L base -L "$THEIRS_LABEL" "$2" "$1" "$3"
 
-		if [[ "$?" == "0" ]]; then
-		  # If the merge was successful (no conflicts) re-encrypt the merged working
-		  # copy file to the incoming "local" temp file $2 which git will then
-		  # update in the index during the "Auto-merging" step.
-		  # Git needs the cleaned copy to avoid triggering the error:
-		  #     error: add_cacheinfo failed to refresh for path 'FILE'; merge aborting.
-		  echo "$(cat $5 | ./.git/crypt/clean $5)" > $2
-		  exit 0
-		else
-		  # If the merge was not successful, copy the merged working copy file to the
-		  # "local" temp file $2 which git will then re-copy back to the working copy
-		  # so the user can fix it manually
-		  cp $5 $2
+		# If the merge was not successful (has conflicts) exit with an error code to
+		# leave the partially-merged file in place for a manual merge.
+		if [[ "$?" != "0" ]]; then
 		  exit 1
 		fi
+
+		# If the merge was successful (no conflicts) re-encrypt the merged temp file $2
+		# which git will then update in the index in a following "Auto-merging" step.
+		# We must explicitly encrypt/clean the file, rather than leave Git to do it,
+		# because we can otherwise trigger safety check failure errors like:
+		#     error: add_cacheinfo failed to refresh for path 'FILE'; merge aborting.
+
+		# To re-encrypt we must first copy the merged file to $5 (the name of the
+		# working-copy file) so the crypt `clean` script can generate the correct hash
+		# salt based on the file's real name, instead of the $2 temp file name.
+		cp "$2" "$5"
+
+		# Now we use the `clean` script to encrypt the merged file contents back to the
+		# temp file $2 where Git expects to find the merge result content.
+		echo "$(cat \"$5\" | ./.git/crypt/clean \"$5\")" > "$2"
 	EOF
 
 	# make scripts executable


### PR DESCRIPTION
Improve the merge driver script to fix a problem that could occur
with complex merges where an encrypted file that couldn't be merged
cleanly would cause the entire merge to fail with the message:

    error: Your local changes to the following files would be overwritten by merge:

        sensitive_file

The bug was caused by being too aggressive in overwriting the working-
copy file $5 with merged content. Doing this early and in all cases
could leave what looks like manually modified files in the working
copy that Git would notice part-way through a multi-step merge and
abort.

The fix is to overwrite the working-copy $5 file only when a merge
is successful (no conflicts) at which point we really need that
specific $5 filename to contain the merged data to encrypt it.
In all other cases, we now leave the working-copy $5 file untouched
and only modify the temporary file $2 which is the file Git expects
to be managed by merge driver scripts.

Other minor improvements in this change are:
- quote ALL uses of $x file name/path arguments to guard against
  failures due to spaces in file paths
- simplify if/then logic to exit fast when needed
- try to better explain in comments what on earth is happening in
  the merge driver script and why.