### PR TITLE
Add --upgrade option to update a transcrypt'ed repo's scripts and configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,10 @@ directory.
              remove  all  transcrypt  configuration  from  the repository and
              leave files in the current working copy decrypted
 
+       --upgrade
+             uninstall and re-install transcrypt configuration in the repository
+             to apply the newest scripts and .gitattributes configuration
+
       -l, --list
              list all of the transparently encrypted files in the repository,
              relative to the top-level directory
@@ -330,8 +334,9 @@ Fixes:
   previously leave the user to manually merge files with a mix of encrypted and
   unencrypted content.
 
-  To apply this fix in projects that already use transcrypt: uninstall and
-  re-init transcrypt, then add `merge=crypt` to the patterns in _.gitattributes_
+  To apply this fix in projects that already use transcrypt: use the `--upgrade`
+  command, or uninstall and re-init transcrypt then add `merge=crypt` to the
+  patterns in _.gitattributes_
 
 Improvements:
 

--- a/tests/test_not_inited.bats
+++ b/tests/test_not_inited.bats
@@ -68,3 +68,10 @@ SETUP_SKIP_INIT_TRANSCRYPT=1
   [ "$status" -ne 0 ]
   [ "${lines[0]}" = "transcrypt: the current repository is not configured" ]
 }
+
+
+@test "not inited: error on --upgrade" {
+  run ../transcrypt --upgrade
+  [ "$status" -ne 0 ]
+  [ "${lines[0]}" = "transcrypt: the current repository is not configured" ]
+}

--- a/transcrypt
+++ b/transcrypt
@@ -616,10 +616,38 @@ uninstall_transcrypt() {
 			;;
 		esac
 
-		printf 'The transcrypt configuration has been completely removed from the repository.\n'
+		if [[ ! $upgrade ]]; then
+			printf 'The transcrypt configuration has been completely removed from the repository.\n'
+		fi
 	else
 		die 1 'uninstallation has been aborted'
 	fi
+}
+
+# uninstall and re-install transcrypt to upgrade scripts and update configuration
+upgrade_transcrypt() {
+	# Keep current cipher and password
+	cipher=$(git config --get --local transcrypt.cipher)
+	password=$(git config --get --local transcrypt.password)
+
+	# Keep contents of .gitattributes
+	ORIG_GITATTRIBUTES=$(cat "$GIT_ATTRIBUTES")
+
+	uninstall_transcrypt
+	save_configuration
+
+	# Re-instate contents of .gitattributes
+	echo "$ORIG_GITATTRIBUTES" > "$GIT_ATTRIBUTES"
+
+	# Update .gitattributes for transcrypt'ed files to include "merge=crypt" config
+	case $OSTYPE in
+	darwin*)
+		/usr/bin/sed -i '' 's/filter=crypt diff=crypt\(.*\)/filter=crypt diff=crypt merge=crypt\1/' "$GIT_ATTRIBUTES"
+		;;
+	linux*)
+		sed -i 's/filter=crypt diff=crypt\(.*\)/filter=crypt diff=crypt merge=crypt\1/' "$GIT_ATTRIBUTES"
+		;;
+	esac
 }
 
 # list all of the currently encrypted files in the repository
@@ -764,6 +792,10 @@ help() {
 		            remove  all  transcrypt  configuration  from  the repository and
 		            leave files in the current working copy decrypted
 
+		     --upgrade
+		            uninstall and re-install transcrypt configuration in the repository
+		            to apply the newest scripts and .gitattributes configuration
+
 		     -l, --list
 		            list all of the transparently encrypted files in the repository,
 		            relative to the top-level directory
@@ -839,6 +871,7 @@ password=''
 rekey=''
 show_file=''
 uninstall=''
+upgrade=''
 
 # used to bypass certain safety checks
 requires_existing_config=''
@@ -885,6 +918,12 @@ while [[ "${1:-}" != '' ]]; do
 		uninstall='true'
 		requires_existing_config='true'
 		requires_clean_repo=''
+		;;
+	--upgrade)
+		upgrade='true'
+		requires_existing_config='true'
+		requires_clean_repo=''
+		interactive=''
 		;;
 	-l | --list)
 		list='true'
@@ -956,6 +995,9 @@ if [[ $list ]]; then
 	exit 0
 elif [[ $uninstall ]]; then
 	uninstall_transcrypt
+	exit 0
+elif [[ $upgrade ]]; then
+	upgrade_transcrypt
 	exit 0
 elif [[ $display_config ]] && [[ $flush_creds ]]; then
 	display_configuration


### PR DESCRIPTION
**WIP** This is a speculative feature, and this PR intended for initial discussions not imminent merge

Automatically and without prompting uninstall then re-init transcrypt
with the existing cipher and password, to apply the latest scripts
and configuration options.

Also modify .gitattributes to add the recommended `merge=crypt`
option for any existing transcrypt'ed files.