### PR TITLE
Remove cached plaintext of secret files on uninstall or flush

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,9 @@ Fixes:
   command, or uninstall and re-init transcrypt then add `merge=crypt` to the
   patterns in _.gitattributes_
 
+- Remove any cached unencrypted from Git's object database when credentials are
+  removed from a repository with a flush or uninstall (#74).
+
 Improvements:
 
 - Add Git pre-commit hook to reject commit of file that should be encrypted but

--- a/tests/test_cleanup.bats
+++ b/tests/test_cleanup.bats
@@ -1,0 +1,92 @@
+#!/usr/bin/env bats
+
+load $BATS_TEST_DIRNAME/_test_helper.bash
+
+SECRET_CONTENT="My secret content"
+SECRET_CONTENT_ENC="U2FsdGVkX1/kkWK36bn3fbq5DY2d+JXL2YWoN/eoXA1XJZEk9JS7j/856rXK9gPn"
+
+@test "cleanup: transcrypt -f flush clears cached plaintext" {
+  encrypt_named_file sensitive_file "$SECRET_CONTENT"
+
+  # Confirm working copy file is decrypted
+  run cat sensitive_file
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "$SECRET_CONTENT" ]
+
+  # Show all changes, caches plaintext due to `cachetextconv` setting
+  run git log -p -- sensitive_file
+  [ "$status" -eq 0 ]
+  [[ "${output}" = *"+$SECRET_CONTENT" ]]  # Check last line of patch
+
+  # Confirm plaintext is cached
+  [[ -f $BATS_TEST_DIRNAME/.git/refs/notes/textconv/crypt ]]
+  cached_plaintext_obj=$(cat $BATS_TEST_DIRNAME/.git/refs/notes/textconv/crypt)
+  run git show "$cached_plaintext_obj"
+  [ "$status" -eq 0 ]
+  [[ "${output}" = *"+$SECRET_CONTENT" ]]  # Check last line of patch
+
+  # Flush credentials
+  run ../transcrypt -f --yes
+  [ "$status" -eq 0 ]
+
+  # Confirm working copy file is encrypted
+  run cat sensitive_file
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "$SECRET_CONTENT_ENC" ]
+
+  # Confirm show all changes shows encrypted content, not plaintext
+  git log -p -- sensitive_file
+  run git log -p -- sensitive_file
+  [ "$status" -eq 0 ]
+  [[ "${output}" = *"+$SECRET_CONTENT_ENC" ]]  # Check last line of patch
+
+  # Confirm plaintext cache ref was cleared
+  [[ ! -e $BATS_TEST_DIRNAME/.git/refs/notes/textconv/crypt ]]
+
+  # Confirm plaintext obj was truly cleared and is no longer visible
+  run git show "$cached_plaintext_obj"
+  [ "$status" -ne 0 ]
+}
+
+@test "cleanup: transcrypt --uninstall clears cached plaintext" {
+  encrypt_named_file sensitive_file "$SECRET_CONTENT"
+
+  # Confirm working copy file is decrypted
+  run cat sensitive_file
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "$SECRET_CONTENT" ]
+
+  # Show all changes, caches plaintext due to `cachetextconv` setting
+  run git log -p -- sensitive_file
+  [ "$status" -eq 0 ]
+  [[ "${output}" = *"+$SECRET_CONTENT" ]]  # Check last line of patch
+
+  # Confirm plaintext is cached
+  [[ -f $BATS_TEST_DIRNAME/.git/refs/notes/textconv/crypt ]]
+  cached_plaintext_obj=$(cat $BATS_TEST_DIRNAME/.git/refs/notes/textconv/crypt)
+  run git show "$cached_plaintext_obj"
+  [ "$status" -eq 0 ]
+  [[ "${output}" = *"+$SECRET_CONTENT" ]]  # Check last line of patch
+
+  # Uninstall
+  run ../transcrypt --uninstall --yes
+  [ "$status" -eq 0 ]
+
+  # Confirm working copy file remains unencrypted (per uninstall contract)
+  run cat sensitive_file
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "$SECRET_CONTENT" ]
+
+  # Confirm show all changes shows encrypted content, not plaintext
+  git log -p -- sensitive_file
+  run git log -p -- sensitive_file
+  [ "$status" -eq 0 ]
+  [[ "${output}" = *"+$SECRET_CONTENT_ENC" ]]  # Check last line of patch
+
+  # Confirm plaintext cache ref was cleared
+  [[ ! -e $BATS_TEST_DIRNAME/.git/refs/notes/textconv/crypt ]]
+
+  # Confirm plaintext obj was truly cleared and is no longer visible
+  run git show "$cached_plaintext_obj"
+  [ "$status" -ne 0 ]
+}

--- a/tests/test_cleanup.bats
+++ b/tests/test_cleanup.bats
@@ -18,12 +18,17 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/kkWK36bn3fbq5DY2d+JXL2YWoN/eoXA1XJZEk9JS7j/856rXK
   [ "$status" -eq 0 ]
   [[ "${output}" = *"+$SECRET_CONTENT" ]]  # Check last line of patch
 
-  # Confirm plaintext is cached
+  # Look up notes ref to cached plaintext
   [[ -f $BATS_TEST_DIRNAME/.git/refs/notes/textconv/crypt ]]
   cached_plaintext_obj=$(cat $BATS_TEST_DIRNAME/.git/refs/notes/textconv/crypt)
+
+  # Confirm plaintext is cached
   run git show "$cached_plaintext_obj"
   [ "$status" -eq 0 ]
   [[ "${output}" = *"+$SECRET_CONTENT" ]]  # Check last line of patch
+
+  # Repack to force all objects into packs (which are trickier to clear)
+  git repack
 
   # Flush credentials
   run ../transcrypt -f --yes
@@ -61,12 +66,17 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/kkWK36bn3fbq5DY2d+JXL2YWoN/eoXA1XJZEk9JS7j/856rXK
   [ "$status" -eq 0 ]
   [[ "${output}" = *"+$SECRET_CONTENT" ]]  # Check last line of patch
 
-  # Confirm plaintext is cached
+  # Look up notes ref to cached plaintext
   [[ -f $BATS_TEST_DIRNAME/.git/refs/notes/textconv/crypt ]]
   cached_plaintext_obj=$(cat $BATS_TEST_DIRNAME/.git/refs/notes/textconv/crypt)
+
+  # Confirm plaintext is cached
   run git show "$cached_plaintext_obj"
   [ "$status" -eq 0 ]
   [[ "${output}" = *"+$SECRET_CONTENT" ]]  # Check last line of patch
+
+  # Repack to force all objects into packs (which are trickier to clear)
+  git repack
 
   # Uninstall
   run ../transcrypt --uninstall --yes

--- a/transcrypt
+++ b/transcrypt
@@ -581,7 +581,9 @@ uninstall_transcrypt() {
 	if [[ $answer =~ $YES_REGEX ]]; then
 		clean_gitconfig
 
-		remove_cached_plaintext
+		if [[ ! $upgrade ]]; then
+			remove_cached_plaintext
+		fi
 
 		# remove helper scripts
 		for script in {clean,smudge,textconv,merge}; do

--- a/transcrypt
+++ b/transcrypt
@@ -496,9 +496,14 @@ clean_gitconfig() {
 		git config --remove-section merge 2>/dev/null || true
 	fi
 
-	# Remove any plaintext of secret files cached due to diff.crypt.cachetextconv='true'
+	# Remove refs to cached plaintext of secret files created due to
+	# diff.crypt.cachetextconv='true'
 	git update-ref -d refs/notes/textconv/crypt
-	git prune
+	# Remove any plaintext objects in Git's DB that used to be referenced by
+	# the above notes, or that have been already been packed.
+	# The key sub-commands jobs we expect this `gc` command to do are something
+	# like: `git prune`, `git repack -ad`
+	git gc --prune=now --quiet
 }
 
 # force the checkout of any files with the crypt filter applied to them;

--- a/transcrypt
+++ b/transcrypt
@@ -495,14 +495,19 @@ clean_gitconfig() {
 	if [[ ! $merge_values ]]; then
 		git config --remove-section merge 2>/dev/null || true
 	fi
+}
 
-	# Remove refs to cached plaintext of secret files created due to
-	# diff.crypt.cachetextconv='true'
+# Remove from the local Git DB any objects containing the cached plaintext of
+# secret files, created due to the setting diff.crypt.cachetextconv='true'
+remove_cached_plaintext() {
+	# Delete ref to cached plaintext objects, to leave these objects
+	# unreferenced and available for removal
 	git update-ref -d refs/notes/textconv/crypt
-	# Remove any plaintext objects in Git's DB that used to be referenced by
-	# the above notes, or that have been already been packed.
-	# The key sub-commands jobs we expect this `gc` command to do are something
-	# like: `git prune`, `git repack -ad`
+
+	# Remove ANY unreferenced objects in Git's object DB (packed or unpacked),
+	# to ensure that cached plaintext objects are also removed.
+	# The vital sub-commands equivalents we require this `gc` command to do are:
+	# `git prune`, `git repack -ad`
 	git gc --prune=now --quiet
 }
 
@@ -546,6 +551,8 @@ flush_credentials() {
 	if [[ $answer =~ $YES_REGEX ]]; then
 		clean_gitconfig
 
+		remove_cached_plaintext
+
 		# re-encrypt any files that had been previously decrypted
 		force_checkout
 
@@ -573,6 +580,8 @@ uninstall_transcrypt() {
 	# only uninstall if the user explicitly confirmed
 	if [[ $answer =~ $YES_REGEX ]]; then
 		clean_gitconfig
+
+		remove_cached_plaintext
 
 		# remove helper scripts
 		for script in {clean,smudge,textconv,merge}; do

--- a/transcrypt
+++ b/transcrypt
@@ -538,7 +538,8 @@ flush_credentials() {
 
 	if [[ $interactive ]]; then
 		printf 'You are about to flush the local credentials; make sure you have saved them elsewhere.\n'
-		printf 'All previously decrypted files will revert to their encrypted form.\n\n'
+		printf 'All previously decrypted files will revert to their encrypted form, and your\n'
+		printf 'repo will be garbage collected to remove any cached plaintext of secret files.\n\n'
 		printf 'Proceed with credential flush? [y/N] '
 		read -r answer
 		printf '\n'
@@ -568,7 +569,8 @@ uninstall_transcrypt() {
 
 	if [[ $interactive ]]; then
 		printf 'You are about to remove all transcrypt configuration from your repository.\n'
-		printf 'All previously encrypted files will remain decrypted in this working copy.\n\n'
+		printf 'All previously encrypted files will remain decrypted in this working copy, but your\n'
+		printf 'repo will be garbage collected to remove any cached plaintext of secret files.\n\n'
 		printf 'Proceed with uninstall? [y/N] '
 		read -r answer
 		printf '\n'

--- a/transcrypt
+++ b/transcrypt
@@ -495,6 +495,10 @@ clean_gitconfig() {
 	if [[ ! $merge_values ]]; then
 		git config --remove-section merge 2>/dev/null || true
 	fi
+
+	# Remove any plaintext of secret files cached due to diff.crypt.cachetextconv='true'
+	git update-ref -d refs/notes/textconv/crypt
+	git prune
 }
 
 # force the checkout of any files with the crypt filter applied to them;


### PR DESCRIPTION
Fix issue #74 where flushing transcrypt credentials or uninstalling can leave cached plaintext versions of secret files in Git's object database with relatively easy-to-find refs.