### PR TITLE
Fix unit tests to pass for newer OpenSSL versions

### DIFF
--- a/.github/workflows/run-bats-core-tests.yml
+++ b/.github/workflows/run-bats-core-tests.yml
@@ -10,9 +10,8 @@ on:
 
 jobs:
   test:
-    # We use older Ubuntu for now to avoid warning from newer OpenSSL (#55)
-    # which break output expectations in some (fragile) tests
-    runs-on: ubuntu-16.04
+    # Test on older Ubuntu with OpenSSL < 1.1 and newer with OpenSSL >= 1.1
+    runs-on: [ubuntu-16.04, ubuntu-18.04]
 
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/run-bats-core-tests.yml
+++ b/.github/workflows/run-bats-core-tests.yml
@@ -11,7 +11,10 @@ on:
 jobs:
   test:
     # Test on older Ubuntu with OpenSSL < 1.1 and newer with OpenSSL >= 1.1
-    runs-on: [ubuntu-16.04, ubuntu-18.04]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-16.04, ubuntu-18.04]
 
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/run-bats-core-tests.yml
+++ b/.github/workflows/run-bats-core-tests.yml
@@ -20,6 +20,9 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
 
+    - name: Print OpenSSL version
+      run: openssl version
+
     - name: Install and set up bats-core
       run: |
         git clone https://github.com/bats-core/bats-core.git /tmp/bats-core-repo

--- a/tests/test_crypt.bats
+++ b/tests/test_crypt.bats
@@ -101,7 +101,7 @@ function check_repo_is_clean {
   SECRET_CONTENT_ENC="U2FsdGVkX19Fp9SwTyQ+tz1OgHNIN0OJ+6sMgHIqPMzfdZ6rZ2iVquS293WnjJMx"
 
   encrypt_named_file "$FILENAME" "$SECRET_CONTENT"
-  [[ "${lines[0]}" = *"Encrypt file \"$FILENAME\"" ]]
+  [[ "${output}" = *"Encrypt file \"$FILENAME\"" ]]
 
   # Working copy is decrypted
   run cat "$FILENAME"

--- a/tests/test_crypt.bats
+++ b/tests/test_crypt.bats
@@ -101,7 +101,7 @@ function check_repo_is_clean {
   SECRET_CONTENT_ENC="U2FsdGVkX19Fp9SwTyQ+tz1OgHNIN0OJ+6sMgHIqPMzfdZ6rZ2iVquS293WnjJMx"
 
   encrypt_named_file "$FILENAME" "$SECRET_CONTENT"
-  [[ "${output}" = *"Encrypt file \"$FILENAME\"" ]]
+  [[ "${output}" = *"Encrypt file \"$FILENAME\""* ]]
 
   # Working copy is decrypted
   run cat "$FILENAME"

--- a/tests/test_merge.bats
+++ b/tests/test_merge.bats
@@ -86,7 +86,7 @@ load $BATS_TEST_DIRNAME/_test_helper.bash
 
   run git merge branch-2
   [ "$status" -ne 0 ]
-  [ "${lines[1]}" = "CONFLICT (content): Merge conflict in sensitive_file" ]
+  [[ "${output}" = *"CONFLICT (content): Merge conflict in sensitive_file"* ]]
 
   run cat sensitive_file
   [ "$status" -eq 0 ]

--- a/tests/test_pre_commit.bats
+++ b/tests/test_pre_commit.bats
@@ -44,11 +44,11 @@ load $BATS_TEST_DIRNAME/_test_helper.bash
   # an encrypted file
   run git commit -m "Added more"
   [ "$status" -ne 0 ]
-  [ "${lines[0]}" = "Transcrypt managed file is not encrypted in the Git index: sensitive_file" ]
-  [ "${lines[1]}" = "You probably staged this file using a tool that does not apply .gitattribute filters as required by Transcrypt." ]
-  [ "${lines[2]}" = "Fix this by re-staging the file with a compatible tool or with Git on the command line:" ]
-  [ "${lines[3]}" = "    git reset -- sensitive_file" ]
-  [ "${lines[4]}" = "    git add sensitive_file" ]
+  [[ "${output}" = *"Transcrypt managed file is not encrypted in the Git index: sensitive_file"* ]]
+  [[ "${output}" = *"You probably staged this file using a tool that does not apply .gitattribute filters as required by Transcrypt."* ]]
+  [[ "${output}" = *"Fix this by re-staging the file with a compatible tool or with Git on the command line:"* ]]
+  [[ "${output}" = *"    git reset -- sensitive_file"* ]]
+  [[ "${output}" = *"    git add sensitive_file"* ]]
 }
 
 @test "pre-commit: warn and don't clobber existing pre-commit hook on init" {


### PR DESCRIPTION
Adjust a couple of output checks to look for expected text anywhere
in the output, instead of at specific lines, so tests will pass
despite warning output like this:

    *** WARNING : deprecated key derivation used.
    Using -iter or -pbkdf2 would be better.

See also #55