### PR TITLE
Ensure Git index is up-to-date before dirty repo  check #37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is based on [Keep a Changelog][1], and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Ensure Git index is up-to-date before checking for dirty repo, to avoid
+  failures seen in CI systems where the repo seems dirty when it isn't. (#37)
+
 ## [2.1.0] - 2020-09-07
 
 This release includes features to make it easier and safer to use transcrypt, in

--- a/transcrypt
+++ b/transcrypt
@@ -127,6 +127,8 @@ run_safety_checks() {
 	# ensure the repository is clean (if it has a HEAD revision) so we can force
 	# checkout files without the destruction of uncommitted changes
 	if [[ $requires_clean_repo ]] && [[ $HEAD_EXISTS ]] && [[ $IS_BARE == 'false' ]]; then
+		# ensure index is up-to-date before dirty check
+		git update-index -q --really-refresh
 		# check if the repo is dirty
 		if ! git diff-index --quiet HEAD --; then
 			die 1 'the repo is dirty; commit or stash your changes before running transcrypt'


### PR DESCRIPTION
Should fix/avoid failures seen in CI systems where the repo seems
dirty when it really isn't.