### PR TITLE
Potential fix for handling small files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog][1], and this project adheres to
 - Zsh completion. (#107)
 - Fix salt generation for partial (patch) commits (#118)
 - Improve command hint to fix secret files not encrypted in index (#120)
+- Fix handling of files with null in first 8 bytes (#116)
 
 ## [2.1.0] - 2020-09-07
 

--- a/transcrypt
+++ b/transcrypt
@@ -126,7 +126,7 @@ git_clean() {
 	trap 'rm -f "$tempfile"' EXIT
 	tee "$tempfile" &>/dev/null
 	# the first bytes of an encrypted file are always "Salted" in Base64
-	firstbytes=$(cat "$tempfile" | head -c8)
+	firstbytes=$(head -c8 "$tempfile")
 	if [[ $firstbytes == "U2FsdGVk" ]]; then
 		cat "$tempfile"
 	else

--- a/transcrypt
+++ b/transcrypt
@@ -126,7 +126,8 @@ git_clean() {
 	trap 'rm -f "$tempfile"' EXIT
 	tee "$tempfile" &>/dev/null
 	# the first bytes of an encrypted file are always "Salted" in Base64
-	firstbytes=$(head -c8 "$tempfile")
+	# The `head + LC_ALL=C tr` command handles binary data in old and new Bash (#116)
+	firstbytes=$(head -c8 "$tempfile" | LC_ALL=C tr -d '\0')
 	if [[ $firstbytes == "U2FsdGVk" ]]; then
 		cat "$tempfile"
 	else

--- a/transcrypt
+++ b/transcrypt
@@ -126,7 +126,7 @@ git_clean() {
 	trap 'rm -f "$tempfile"' EXIT
 	tee "$tempfile" &>/dev/null
 	# the first bytes of an encrypted file are always "Salted" in Base64
-	read -rn 8 firstbytes <"$tempfile"
+	firstbytes=$(cat "$tempfile" | head -c8)
 	if [[ $firstbytes == "U2FsdGVk" ]]; then
 		cat "$tempfile"
 	else


### PR DESCRIPTION
See #116 

The `read -rn 8` command doesn't seem to cope with small files, and
does all kinds of strange things when I try running it manually on
latest macOS to test, including:
- not reading anything at all from files with short first lines
- reading too much from files with long first lines (more than 8 chars)

Overall the `head -c8` approach used everywhere else to do this work
is probably safer, and should work with small files as well.