### PR TITLE
Remove Ubuntu 16.04 LTS from test matrix

### DIFF
--- a/.github/workflows/run-bats-core-tests.yml
+++ b/.github/workflows/run-bats-core-tests.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04, macos-latest]
+        os: [ubuntu-18.04, ubuntu-20.04, macos-latest]
 
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it


### PR DESCRIPTION
The "Xenial Xerus" version of Ubuntu is EOL (end-of-life) as of 2021-04-30.

See:
- https://help.ubuntu.com/community/EOL