### PR TITLE
New cmd to add file to crypt list (.gitattributes)

### DIFF
--- a/tests/test_crypt.bats
+++ b/tests/test_crypt.bats
@@ -139,6 +139,43 @@ function check_repo_is_clean {
   rm "$FILENAME"
 }
 
+@test "crypt: add file to crypt" {
+  # git add-crypt add file to gitattributes
+
+  # add file 1
+  git add-crypt foobar
+  run cat .gitattributes
+  echo "${lines[@]}"
+  [[ "$status" -eq 0 ]]
+  [[ "${#lines[@]}" = "2" ]]
+  [[ "${lines[1]}" = "foobar  filter=crypt diff=crypt merge=crypt" ]]
+
+  # add pattern 2
+  git add-crypt config/*.json
+  run cat .gitattributes
+  [[ "$status" -eq 0 ]]
+  [[ "${#lines[@]}" = "3" ]]
+  [[ "${lines[2]}" = "config/*.json  filter=crypt diff=crypt merge=crypt" ]]
+
+  # add pattern 2
+  git add-crypt pattern2
+  run cat .gitattributes
+  [[ "$status" -eq 0 ]]
+  [[ "${#lines[@]}" = "4" ]]
+  [[ "${lines[3]}" = "pattern2  filter=crypt diff=crypt merge=crypt" ]]
+
+  # test ignore adding duplicate pattern
+  git add-crypt pattern2
+  git add-crypt foobar
+  git add-crypt config/*.json
+  run cat .gitattributes
+  [[ "$status" -eq 0 ]]
+  [[ "${#lines[@]}" = "4" ]]  # no new line added
+  [[ "${lines[1]}" = "foobar  filter=crypt diff=crypt merge=crypt" ]]
+  [[ "${lines[2]}" = "config/*.json  filter=crypt diff=crypt merge=crypt" ]]
+  [[ "${lines[3]}" = "pattern2  filter=crypt diff=crypt merge=crypt" ]]
+}
+
 @test "crypt: transcrypt --upgrade applies new merge driver" {
   VERSION=$(../transcrypt -v | awk '{print $2}')
 

--- a/tests/test_init.bats
+++ b/tests/test_init.bats
@@ -55,6 +55,8 @@ SETUP_SKIP_INIT_TRANSCRYPT=1
   [[ "$(git config --get merge.renormalize)" = "true" ]]
 
   [[ "$(git config --get alias.ls-crypt)" = "!git -c core.quotePath=false ls-files | git -c core.quotePath=false check-attr --stdin filter | awk 'BEGIN { FS = \":\" }; /crypt$/{ print \$1 }'" ]]
+  # shellcheck disable=SC2016
+  [[ "$(git config --get alias.add-crypt)" = '!"$(git rev-parse --git-common-dir)"/crypt/transcrypt add' ]]
 }
 
 @test "init: show details for --display" {

--- a/transcrypt
+++ b/transcrypt
@@ -198,12 +198,12 @@ git_merge() {
 }
 
 git_add() {
-  gather_repo_metadata
-  for var in "$@"; do
-    line="$var  filter=crypt diff=crypt merge=crypt"
-    grep -qxF "$line" "${GIT_ATTRIBUTES}" || echo "$line" >> "${GIT_ATTRIBUTES}"
-    sync
-  done
+	gather_repo_metadata
+	for var in "$@"; do
+		line="$var  filter=crypt diff=crypt merge=crypt"
+		grep -qxF "$line" "${GIT_ATTRIBUTES}" || echo "$line" >>"${GIT_ATTRIBUTES}"
+		sync
+	done
 }
 
 # verify that all requirements have been met
@@ -513,11 +513,11 @@ save_configuration() {
 	if [[ -d $(git rev-parse --git-common-dir) ]]; then
 		# this allows us to support multiple working trees via git-worktree
 		# ...but the --git-common-dir flag was only added in November 2014
-	  # shellcheck disable=SC2016
-    git_dir='"$(git rev-parse --git-common-dir)"'
+		# shellcheck disable=SC2016
+		git_dir='"$(git rev-parse --git-common-dir)"'
 	else
-	  # shellcheck disable=SC2016
-    git_dir='"$(git rev-parse --git-dir)"'
+		# shellcheck disable=SC2016
+		git_dir='"$(git rev-parse --git-dir)"'
 	fi
 	git config filter.crypt.clean "$git_dir"'/crypt/clean %f'
 	git config filter.crypt.smudge "$git_dir"'/crypt/smudge'

--- a/transcrypt
+++ b/transcrypt
@@ -197,6 +197,15 @@ git_merge() {
 	cat "$5" | ./.git/crypt/clean "$5" >"$2"
 }
 
+git_add() {
+  gather_repo_metadata
+  for var in "$@"; do
+    line="$var  filter=crypt diff=crypt merge=crypt"
+    grep -qxF "$line" "${GIT_ATTRIBUTES}" || echo "$line" >> "${GIT_ATTRIBUTES}"
+    sync
+  done
+}
+
 # verify that all requirements have been met
 run_safety_checks() {
 	# validate that we're in a git repository
@@ -504,24 +513,16 @@ save_configuration() {
 	if [[ -d $(git rev-parse --git-common-dir) ]]; then
 		# this allows us to support multiple working trees via git-worktree
 		# ...but the --git-common-dir flag was only added in November 2014
-		# shellcheck disable=SC2016
-		git config filter.crypt.clean '"$(git rev-parse --git-common-dir)"/crypt/clean %f'
-		# shellcheck disable=SC2016
-		git config filter.crypt.smudge '"$(git rev-parse --git-common-dir)"/crypt/smudge'
-		# shellcheck disable=SC2016
-		git config diff.crypt.textconv '"$(git rev-parse --git-common-dir)"/crypt/textconv'
-		# shellcheck disable=SC2016
-		git config merge.crypt.driver '"$(git rev-parse --git-common-dir)"/crypt/merge %O %A %B %L %P'
+	  # shellcheck disable=SC2016
+    git_dir='"$(git rev-parse --git-common-dir)"'
 	else
-		# shellcheck disable=SC2016
-		git config filter.crypt.clean '"$(git rev-parse --git-dir)"/crypt/clean %f'
-		# shellcheck disable=SC2016
-		git config filter.crypt.smudge '"$(git rev-parse --git-dir)"/crypt/smudge'
-		# shellcheck disable=SC2016
-		git config diff.crypt.textconv '"$(git rev-parse --git-dir)"/crypt/textconv'
-		# shellcheck disable=SC2016
-		git config merge.crypt.driver '"$(git rev-parse --git-dir)"/crypt/merge %O %A %B %L %P'
+	  # shellcheck disable=SC2016
+    git_dir='"$(git rev-parse --git-dir)"'
 	fi
+	git config filter.crypt.clean "$git_dir"'/crypt/clean %f'
+	git config filter.crypt.smudge "$git_dir"'/crypt/smudge'
+	git config diff.crypt.textconv "$git_dir"'/crypt/textconv'
+	git config merge.crypt.driver "$git_dir"'/crypt/merge %O %A %B %L %P'
 	git config filter.crypt.required 'true'
 	git config diff.crypt.cachetextconv 'true'
 	git config diff.crypt.binary 'true'
@@ -530,6 +531,7 @@ save_configuration() {
 
 	# add a git alias for listing encrypted files
 	git config alias.ls-crypt "!git -c core.quotePath=false ls-files | git -c core.quotePath=false check-attr --stdin filter | awk 'BEGIN { FS = \":\" }; /crypt$/{ print \$1 }'"
+	git config alias.add-crypt "!$git_dir"'/crypt/transcrypt add'
 }
 
 # display the current configuration settings
@@ -1027,6 +1029,11 @@ while [[ "${1:-}" != '' ]]; do
 	merge)
 		shift
 		git_merge "$@"
+		exit $?
+		;;
+	add)
+		shift
+		git_add "$@"
 		exit $?
 		;;
 	-c | --cipher)

--- a/transcrypt
+++ b/transcrypt
@@ -52,6 +52,7 @@ realpath() {
 }
 
 # establish repository metadata and directory handling
+# shellcheck disable=SC2155
 gather_repo_metadata() {
 	# whether or not transcrypt is already configured
 	readonly CONFIGURED=$(git config --get --local transcrypt.version 2>/dev/null)


### PR DESCRIPTION
This PR adds a convenient command that quickly adds file/patterns to .gitattribute. The command is available as git alias too (similar to git ls-crypt)

The command also checks if the given file/pattern already exists in the file, and it will be a no-op if the line already exists.


```sh
$ cat .gitattributes
#pattern  filter=crypt diff=crypt merge=crypt
$ git add-crypt foobar
$ cat .gitattributes
#pattern  filter=crypt diff=crypt merge=crypt
foobar  filter=crypt diff=crypt merge=crypt
$ git add-crypt 'configs/*.json'
$ cat .gitattributes
#pattern  filter=crypt diff=crypt merge=crypt
foobar  filter=crypt diff=crypt merge=crypt
configs/*.json  filter=crypt diff=crypt merge=crypt
$ git add-crypt 'foobar'
$ git add-crypt 'foobar'
$ git add-crypt 'foobar'
$ cat .gitattributes
#pattern  filter=crypt diff=crypt merge=crypt
foobar  filter=crypt diff=crypt merge=crypt
configs/*.json  filter=crypt diff=crypt merge=crypt
```
