### PR TITLE
Use core attributesFile from worktree

### DIFF
--- a/transcrypt
+++ b/transcrypt
@@ -82,7 +82,7 @@ gather_repo_metadata() {
 
 	# the current git repository's gitattributes file
 	local CORE_ATTRIBUTES
-	CORE_ATTRIBUTES=$(git config --get --local --path core.attributesFile 2>/dev/null || printf '')
+	CORE_ATTRIBUTES=$(git config --get --local --path core.attributesFile 2>/dev/null || git config --get --path core.attributesFile 2>/dev/null || printf '')
 	if [[ $CORE_ATTRIBUTES ]]; then
 		readonly GIT_ATTRIBUTES=$CORE_ATTRIBUTES
 	elif [[ $IS_BARE == 'true' ]] || [[ $IS_VCSH == 'true' ]]; then


### PR DESCRIPTION
When using attribute file overrides (for example if override in .dotfiles or by other includes), get the core.attributesFile from the current worktree if available.