### PR TITLE
#176 : Correction of zsh completion

### DIFF
--- a/contrib/zsh/_transcrypt
+++ b/contrib/zsh/_transcrypt
@@ -18,7 +18,7 @@ _transcrypt() {
 		'(-f --flush-credentials -c --cipher -p --password -r --rekey -u --uninstall)'{-f,--flush-credentials}'[flush cached credentials]' \
 		'(-F --force -d --display -u --uninstall)'{-F,--force}'[ignore repository clean state]' \
 		'(-u --uninstall -c --cipher -d --display -f --flush-credentials -p --password -r --rekey)'{-u,--uninstall}'[uninstall transcrypt]' \
-		'(--set-openssl-path -c --cipher -d --display -f --flush-credentials -p --password -r --rekey)'{--set-openssl-path}'[use OpenSSL at this path]' \
+		'(-set-openssl-path -c --cipher -d --display -f --flush-credentials -p --password -r --rekey)--set-openssl-path=[use OpenSSL at this path]:file:->file' \
 		'(--upgrade -c --cipher -d --display -f --flush-credentials -p --password -r --rekey)--upgrade[upgrade transcrypt]' \
 		'(-i --import-gpg -c --cipher -p --password -d --display -f --flush-credentials -u --uninstall)'{-i,--import-gpg=}'[import config from gpg file]:file:->file' \
 		&& return 0

--- a/contrib/zsh/_transcrypt
+++ b/contrib/zsh/_transcrypt
@@ -6,12 +6,12 @@ _transcrypt() {
 
 	_arguments \
 		'(- 1 *)'{-l,--list}'[list encrypted files]' \
-		'(- 1 *)'{-s,--show-raw=}'[show raw file]:file:->file' \
-		'(- 1 *)'{-e,--export-gpg=}'[export config to gpg recipient]:recipient:' \
+		'(- 1 *)'{-s=,--show-raw=}'[show raw file]:file:->file' \
+		'(- 1 *)'{-e=,--export-gpg=}'[export config to gpg recipient]:recipient:' \
 		'(- 1 *)'{-v,--version}'[print version]' \
 		'(- 1 *)'{-h,--help}'[view help message]' \
-		'(-c --cipher -d --display -f --flush-credentials -u --uninstall)'{-c,--cipher=}'[specify encryption cipher]:cipher:->cipher' \
-		'(-p --password -d --display -f --flush-credentials -u --uninstall)'{-p,--password=}'[specify encryption password]:password:' \
+		'(-c --cipher -d --display -f --flush-credentials -u --uninstall)'{-c=,--cipher=}'[specify encryption cipher]:cipher:->cipher' \
+		'(-p --password -d --display -f --flush-credentials -u --uninstall)'{-p=,--password=}'[specify encryption password]:password:' \
 		'(-y --yes)'{-y,--yes}'[assume yes and accept defaults]' \
 		'(-d --display -p --password -c --cipher -r --rekey -u --uninstall)'{-d,--display}'[display current credentials]' \
 		'(-r --rekey -d --display -f --flush-credentials -u --uninstall)'{-r,--rekey}'[rekey all encrypted files]' \
@@ -20,12 +20,12 @@ _transcrypt() {
 		'(-u --uninstall -c --cipher -d --display -f --flush-credentials -p --password -r --rekey)'{-u,--uninstall}'[uninstall transcrypt]' \
 		'(-set-openssl-path -c --cipher -d --display -f --flush-credentials -p --password -r --rekey)--set-openssl-path=[use OpenSSL at this path]:file:->file' \
 		'(--upgrade -c --cipher -d --display -f --flush-credentials -p --password -r --rekey)--upgrade[upgrade transcrypt]' \
-		'(-i --import-gpg -c --cipher -p --password -d --display -f --flush-credentials -u --uninstall)'{-i,--import-gpg=}'[import config from gpg file]:file:->file' \
+		'(-i --import-gpg -c --cipher -p --password -d --display -f --flush-credentials -u --uninstall)'{-i=,--import-gpg=}'[import config from gpg file]:file:->file' \
 		&& return 0
 
 	case $state in
 		cipher)
-			ciphers=( ${(f)"$(_call_program available-ciphers openssl list-cipher-commands)"} )
+			ciphers=( ${(f)"$(_call_program available-ciphers openssl list -cipher-commands)"} )
 			_describe -t available-ciphers 'available ciphers' ciphers
 			;;
 		file)


### PR DESCRIPTION
I'm new to completion.
I read this https://github.com/zsh-users/zsh-completions/blob/master/zsh-completions-howto.org to understand ZSH completion.

It seems to work now : 
```
transcrypt -<TAB>                                                                                                                                                                                                                    
 -- option --
--cipher             -c  -- specify encryption cipher                                                                                                                                                                                       
--display            -d  -- display current credentials                                                                                                                                                                                     
--export-gpg         -e  -- export config to gpg recipient                                                                                                                                                                                  
--flush-credentials  -f  -- flush cached credentials                                                                                                                                                                                        
--force              -F  -- ignore repository clean state                                                                                                                                                                                   
--help               -h  -- view help message                                                                                                                                                                                               
--import-gpg         -i  -- import config from gpg file                                                                                                                                                                                     
--list               -l  -- list encrypted files                                                                                                                                                                                            
--password           -p  -- specify encryption password                                                                                                                                                                                     
--rekey              -r  -- rekey all encrypted files                                                                                                                                                                                       
--set-openssl-path       -- use OpenSSL at this path                                                                                                                                                                                        
--show-raw           -s  -- show raw file                                                                                                                                                                                                   
--uninstall          -u  -- uninstall transcrypt                                                                                                                                                                                            
--upgrade                -- upgrade transcrypt                                                                                                                                                                                              
--version            -v  -- print version                                                                                                                                                                                                   
--yes                -y  -- assume yes and accept defaults
```

and with the option "--set-openssl-path" it display folder tree for the path.
I'm just not sure why when this option is used, the other can't be?
the other options : 
``` 
-c --cipher -d --display -f --flush-credentials -p --password -r --rekey
``` 

Try to correct #176 