### PR TITLE
change xxd dependency from hard to soft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ system, you must also run the `--upgrade` command in each repository:
 
 ### Changed
 
+- Remove hard dependency on `xxd` which is often a heavy requirement because it
+  is only available with Vim on some platforms. Fall back to `printf` with full
+  %b support or `perl` when either of these are available, and only require
+  `xxd` when it is the only viable option (#181)
 - Prevent global options set in `GREP_OPTIONS` enviroment variable from
   breaking transcrypt's use of grep (#166)
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,6 +6,8 @@ The requirements to run transcrypt are minimal:
 - Git
 - OpenSSL
 - `column` command (on Ubuntu/Debian install `bsdmainutils`)
+- if using OpenSSL version 3, one of `xxd` (on Ubuntu/Debian is included with `vim`)
+  or `perl` or `printf` (with %b directive) command
 
 ...and optionally:
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,8 +6,8 @@ The requirements to run transcrypt are minimal:
 - Git
 - OpenSSL
 - `column` command (on Ubuntu/Debian install `bsdmainutils`)
-- if using OpenSSL version 3, one of `xxd` (on Ubuntu/Debian is included with `vim`)
-  or `perl` or `printf` (with %b directive) command
+- if using OpenSSL 3+ one of: `xxd` (on Ubuntu/Debian is included with `vim`)
+  or `printf` command (with %b directive) or `perl`
 
 ...and optionally:
 
@@ -74,4 +74,3 @@ collection:
 or via the packages system:
 
     # `pkg install -y security/transcrypt`
-

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,8 +6,6 @@ The requirements to run transcrypt are minimal:
 - Git
 - OpenSSL
 - `column` command (on Ubuntu/Debian install `bsdmainutils`)
-- `xxd` command if using OpenSSL version 3
-  (on Ubuntu/Debian is included with `vim`)
 
 ...and optionally:
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ The requirements to run transcrypt are minimal:
 - Git
 - OpenSSL
 - `column` and `hexdump` commands (on Ubuntu/Debian install `bsdmainutils`)
+- if using OpenSSL version 3, one of `xxd` (on Ubuntu/Debian is included with `vim`)
+  or `perl` or `printf` (with %b directive) command
 
 ...and optionally:
 

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ The requirements to run transcrypt are minimal:
 - Git
 - OpenSSL
 - `column` and `hexdump` commands (on Ubuntu/Debian install `bsdmainutils`)
-- if using OpenSSL version 3, one of `xxd` (on Ubuntu/Debian is included with `vim`)
-  or `perl` or `printf` (with %b directive) command
+- if using OpenSSL 3+ one of: `xxd` (on Ubuntu/Debian is included with `vim`)
+  or `printf` command (with %b directive) or `perl`
 
 ...and optionally:
 

--- a/README.md
+++ b/README.md
@@ -56,8 +56,6 @@ The requirements to run transcrypt are minimal:
 - Git
 - OpenSSL
 - `column` and `hexdump` commands (on Ubuntu/Debian install `bsdmainutils`)
-- `xxd` command if using OpenSSL version 3
-  (on Ubuntu/Debian is included with `vim`)
 
 ...and optionally:
 

--- a/transcrypt
+++ b/transcrypt
@@ -216,7 +216,7 @@ git_clean() {
 		if [ "$(is_salt_prefix_workaround_required)" == "true" ]; then
 			# Encrypt the file to base64, ensuring it includes the prefix 'Salted__' with the salt. #133
 			(
-				echo -n "Salted__" && echo -n "$salt" | xxd -r -p &&
+				echo -n "Salted__" && echo -n "$salt" | sed "s/../\\\\x&/g" | xargs -0 printf "%b" &&
 					# Encrypt file to binary ciphertext
 					ENC_PASS=$password "$openssl_path" enc -e "-${cipher}" -md MD5 -pass env:ENC_PASS -S "$salt" -in "$tempfile"
 			) |
@@ -396,11 +396,6 @@ run_safety_checks() {
 	for cmd in {column,grep,mktemp,"${openssl_path}",sed,tee}; do
 		command -v "$cmd" >/dev/null || die 'required command "%s" was not found' "$cmd"
 	done
-	# check for extra `xxd` dependency when running against OpenSSL version 3+
-	if [ "$(is_salt_prefix_workaround_required)" == "true" ]; then
-		cmd="xxd"
-		command -v "$cmd" >/dev/null || die 'required command "%s" was not found' "$cmd"
-	fi
 
 	# ensure the repository is clean (if it has a HEAD revision) so we can force
 	# checkout files without the destruction of uncommitted changes

--- a/transcrypt
+++ b/transcrypt
@@ -191,18 +191,20 @@ is_salt_prefix_workaround_required() {
 # shellcheck disable=SC2155
 readonly IS_PRINTF_BIN_SUPPORTED=$([[ "$(echo -n "41" | sed "s/../\\\\x&/g" | xargs -0 printf "%b")" == "A" ]] && echo 'true' || echo 'false')
 
+# Apply one of three methods to convert a hex string to binary data, or
 hex_to_bin() {
+	# alternative 1 but xxd often only comes with a vim install
 	if command -v "xxd" >/dev/null; then
-		# alternative 1 but xxd only comes with vim
 		xxd -r -p
-	elif command -v "perl" >/dev/null; then
-		# alternative 2 as perl is fairly common
-		perl -pe "s/([0-9A-Fa-f]{2})/chr(hex(\$1))/eg"
+	# alternative 2, but requires printf that supports "%b"
+	# (macOS /usr/bin/printf doesn't)
 	elif $IS_PRINTF_BIN_SUPPORTED; then
-		# alternative 3 but requires printf that supports "%b" e.g. macOS /usr/bin/printf doesn't
 		sed "s/../\\\\x&/g" | xargs -0 printf "%b"
+	# alternative 3 as perl is fairly common
+	elif command -v "perl" >/dev/null; then
+		perl -pe "s/([0-9A-Fa-f]{2})/chr(hex(\$1))/eg"
 	else
-		die 'required command not found: xxd or perl or printf that supports "%%b"'
+		die 'required command not found: xxd, or printf that supports "%%b", or perl'
 	fi
 }
 
@@ -415,7 +417,10 @@ run_safety_checks() {
 		command -v "$cmd" >/dev/null || die 'required command "%s" was not found' "$cmd"
 	done
 
-	echo -n "41" | hex_to_bin >/dev/null
+	# check for a working method to convert a hex string to binary data
+	if [ "$(is_salt_prefix_workaround_required)" == "true" ]; then
+		echo -n "41" | hex_to_bin >/dev/null
+	fi
 
 	# ensure the repository is clean (if it has a HEAD revision) so we can force
 	# checkout files without the destruction of uncommitted changes

--- a/transcrypt
+++ b/transcrypt
@@ -188,6 +188,24 @@ is_salt_prefix_workaround_required() {
 # (keyed with a combination of the filename and transcrypt password), and
 # then use the last 16 bytes of that HMAC for the file's unique salt.
 
+# shellcheck disable=SC2155
+readonly IS_PRINTF_BIN_SUPPORTED=$([[ "$(echo -n "41" | sed "s/../\\\\x&/g" | xargs -0 printf "%b")" == "A" ]] && echo 'true' || echo 'false')
+
+hex_to_bin() {
+	if command -v "xxd" >/dev/null; then
+		# alternative 1 but xxd only comes with vim
+		xxd -r -p
+	elif command -v "perl" >/dev/null; then
+		# alternative 2 as perl is fairly common
+		perl -pe "s/([0-9A-Fa-f]{2})/chr(hex(\$1))/eg"
+	elif $IS_PRINTF_BIN_SUPPORTED; then
+		# alternative 3 but requires printf that supports "%b" e.g. macOS /usr/bin/printf doesn't
+		sed "s/../\\\\x&/g" | xargs -0 printf "%b"
+	else
+		die 'required command not found: xxd or perl or printf that supports "%%b"'
+	fi
+}
+
 git_clean() {
 	context=$(extract_context_name_from_name_value_arg "$1")
 	[[ "$context" ]] && shift
@@ -216,7 +234,7 @@ git_clean() {
 		if [ "$(is_salt_prefix_workaround_required)" == "true" ]; then
 			# Encrypt the file to base64, ensuring it includes the prefix 'Salted__' with the salt. #133
 			(
-				echo -n "Salted__" && echo -n "$salt" | sed "s/../\\\\x&/g" | xargs -0 printf "%b" &&
+				echo -n "Salted__" && echo -n "$salt" | hex_to_bin &&
 					# Encrypt file to binary ciphertext
 					ENC_PASS=$password "$openssl_path" enc -e "-${cipher}" -md MD5 -pass env:ENC_PASS -S "$salt" -in "$tempfile"
 			) |
@@ -396,6 +414,8 @@ run_safety_checks() {
 	for cmd in {column,grep,mktemp,"${openssl_path}",sed,tee}; do
 		command -v "$cmd" >/dev/null || die 'required command "%s" was not found' "$cmd"
 	done
+
+	echo -n "41" | hex_to_bin >/dev/null
 
 	# ensure the repository is clean (if it has a HEAD revision) so we can force
 	# checkout files without the destruction of uncommitted changes


### PR DESCRIPTION
xxd is a dependency for openssl 3+ environments,
but xxd is packaged with vim,
which basically translates to
**"transcrypt has a dependency on vim"** 🙄🤦‍♂️ 

In order to keep the dependencies slim, and vim is not slim,
here's an attempt to replace xxd with sed and xargs.

Alternatively, perl also seems to work `perl -pe "s/([0-9A-Fa-f]{2})/chr(hex(\$1))/eg"` instead of `xxd -r -p`. Maybe there are other/better ways.

sed+xargs, and even perl, are much more easily available, if not readily available, than xxd (vim). Think automation (CI/CD, docker) - you don't install a full-blown editor, but if you need to decrypt with transcrypt, currently you need to install one...

NOTE I am not 💯 sure this is safe and that there's no edge cases, but it looks alright e.g.

```
echo -n "deadbeaf00000bad" | xxd -r -p
echo -n "deadbeaf00000bad" | sed "s/../\\\\x&/g" | xargs -0 printf "%b"
echo -n "deadbeaf00000bad" | perl -pe "s/([0-9A-Fa-f]{2})/chr(hex(\$1))/eg"
```