### PR TITLE
better support for git worktree

### DIFF
--- a/tests/test_contexts.bats
+++ b/tests/test_contexts.bats
@@ -66,10 +66,10 @@ function teardown {
 
   # Use --git-common-dir if available (Git post Nov 2014) otherwise --git-dir
   # shellcheck disable=SC2016
-  [ "$(git config --get filter.crypt.clean)" = '"$(git config transcrypt.crypt-dir 2>/dev/null || printf ''%s/crypt'' ""$(git rev-parse --git-dir)"")"/transcrypt clean context=default %f' ]
-  [ "$(git config --get filter.crypt.smudge)" = '"$(git config transcrypt.crypt-dir 2>/dev/null || printf ''%s/crypt'' ""$(git rev-parse --git-dir)"")"/transcrypt smudge context=default' ]
-  [ "$(git config --get diff.crypt.textconv)" = '"$(git config transcrypt.crypt-dir 2>/dev/null || printf ''%s/crypt'' ""$(git rev-parse --git-dir)"")"/transcrypt textconv context=default' ]
-  [ "$(git config --get merge.crypt.driver)" = '"$(git config transcrypt.crypt-dir 2>/dev/null || printf ''%s/crypt'' ""$(git rev-parse --git-dir)"")"/transcrypt merge context=default %O %A %B %L %P' ]
+  [ "$(git config --get filter.crypt.clean)" = '"$(git config transcrypt.crypt-dir 2>/dev/null || printf ''%s/crypt'' ""$(git rev-parse --git-common-dir)"")"/transcrypt clean context=default %f' ]
+  [ "$(git config --get filter.crypt.smudge)" = '"$(git config transcrypt.crypt-dir 2>/dev/null || printf ''%s/crypt'' ""$(git rev-parse --git-common-dir)"")"/transcrypt smudge context=default' ]
+  [ "$(git config --get diff.crypt.textconv)" = '"$(git config transcrypt.crypt-dir 2>/dev/null || printf ''%s/crypt'' ""$(git rev-parse --git-common-dir)"")"/transcrypt textconv context=default' ]
+  [ "$(git config --get merge.crypt.driver)" = '"$(git config transcrypt.crypt-dir 2>/dev/null || printf ''%s/crypt'' ""$(git rev-parse --git-common-dir)"")"/transcrypt merge context=default %O %A %B %L %P' ]
 
   [[ $(git config --get filter.crypt.required) = "true" ]]
   [[ $(git config --get diff.crypt.cachetextconv) = "true" ]]

--- a/tests/test_crypt.bats
+++ b/tests/test_crypt.bats
@@ -224,7 +224,7 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/6ilR0PmJpAyCF7iG3+k4aBwbgVd48WaQXznsg42nXbQrlWsf/
   run cat .gitattributes
   [ "${lines[0]}" = "sensitive_file filter=crypt diff=crypt" ]
   # Check merge driver is not installed
-  [ ! "$(git config --get merge.crypt.driver)" = '"$(git config transcrypt.crypt-dir 2>/dev/null || printf ''%s/crypt'' ""$(git rev-parse --git-dir)"")"/transcrypt merge %O %A %B %L %P' ]
+  [ ! "$(git config --get merge.crypt.driver)" = '"$(git config transcrypt.crypt-dir 2>/dev/null || printf ''%s/crypt'' ""$(git rev-parse --git-common-dir)"")"/transcrypt merge %O %A %B %L %P' ]
 
   run git config --get --local transcrypt.version
   [ "${lines[0]}" = "0.0" ]
@@ -254,7 +254,7 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/6ilR0PmJpAyCF7iG3+k4aBwbgVd48WaQXznsg42nXbQrlWsf/
   [ "${lines[0]}" = "$SECRET_CONTENT" ]
 
   # Check merge driver is installed
-  [ "$(git config --get merge.crypt.driver)" = '"$(git config transcrypt.crypt-dir 2>/dev/null || printf ''%s/crypt'' ""$(git rev-parse --git-dir)"")"/transcrypt merge context=default %O %A %B %L %P' ]
+  [ "$(git config --get merge.crypt.driver)" = '"$(git config transcrypt.crypt-dir 2>/dev/null || printf ''%s/crypt'' ""$(git rev-parse --git-common-dir)"")"/transcrypt merge context=default %O %A %B %L %P' ]
 
   # Check .gitattributes is updated to include merge driver
   run cat .gitattributes

--- a/tests/test_init.bats
+++ b/tests/test_init.bats
@@ -38,10 +38,10 @@ SETUP_SKIP_INIT_TRANSCRYPT=1
 
   # Use --git-common-dir if available (Git post Nov 2014) otherwise --git-dir
   # shellcheck disable=SC2016
-  [ "$(git config --get filter.crypt.clean)" = '"$(git config transcrypt.crypt-dir 2>/dev/null || printf ''%s/crypt'' ""$(git rev-parse --git-dir)"")"/transcrypt clean context=default %f' ]
-  [ "$(git config --get filter.crypt.smudge)" = '"$(git config transcrypt.crypt-dir 2>/dev/null || printf ''%s/crypt'' ""$(git rev-parse --git-dir)"")"/transcrypt smudge context=default' ]
-  [ "$(git config --get diff.crypt.textconv)" = '"$(git config transcrypt.crypt-dir 2>/dev/null || printf ''%s/crypt'' ""$(git rev-parse --git-dir)"")"/transcrypt textconv context=default' ]
-  [ "$(git config --get merge.crypt.driver)" = '"$(git config transcrypt.crypt-dir 2>/dev/null || printf ''%s/crypt'' ""$(git rev-parse --git-dir)"")"/transcrypt merge context=default %O %A %B %L %P' ]
+  [ "$(git config --get filter.crypt.clean)" = '"$(git config transcrypt.crypt-dir 2>/dev/null || printf ''%s/crypt'' ""$(git rev-parse --git-common-dir)"")"/transcrypt clean context=default %f' ]
+  [ "$(git config --get filter.crypt.smudge)" = '"$(git config transcrypt.crypt-dir 2>/dev/null || printf ''%s/crypt'' ""$(git rev-parse --git-common-dir)"")"/transcrypt smudge context=default' ]
+  [ "$(git config --get diff.crypt.textconv)" = '"$(git config transcrypt.crypt-dir 2>/dev/null || printf ''%s/crypt'' ""$(git rev-parse --git-common-dir)"")"/transcrypt textconv context=default' ]
+  [ "$(git config --get merge.crypt.driver)" = '"$(git config transcrypt.crypt-dir 2>/dev/null || printf ''%s/crypt'' ""$(git rev-parse --git-common-dir)"")"/transcrypt merge context=default %O %A %B %L %P' ]
 
   [ "$(git config --get filter.crypt.required)" = "true" ]
   [ "$(git config --get diff.crypt.cachetextconv)" = "true" ]

--- a/transcrypt
+++ b/transcrypt
@@ -656,7 +656,7 @@ save_configuration() {
 
 	# write the filter settings. Sorry for the horrific quote escaping below...
 	# shellcheck disable=SC2016
-	transcrypt_path='"$(git config transcrypt.crypt-dir 2>/dev/null || printf %s/crypt ""$(git rev-parse --git-dir)"")"/transcrypt'
+	transcrypt_path='"$(git config transcrypt.crypt-dir 2>/dev/null || printf %s/crypt ""$(git rev-parse --git-common-dir)"")"/transcrypt'
 
 	# Ensure filter attributes are always set for the default (unspecified) context
 	git config filter.crypt.clean "$transcrypt_path clean context=default %f"

--- a/transcrypt
+++ b/transcrypt
@@ -97,7 +97,7 @@ gather_repo_metadata() {
 	readonly IS_BARE=$(git rev-parse --is-bare-repository 2>/dev/null || printf 'false')
 
 	# the current git repository's .git directory
-	readonly RELATIVE_GIT_DIR=$(git rev-parse --git-dir 2>/dev/null || printf '')
+	readonly RELATIVE_GIT_DIR=$(git rev-parse --git-common-dir 2>/dev/null || printf '')
 	readonly GIT_DIR=$(realpath "$RELATIVE_GIT_DIR" 2>/dev/null)
 
 	# Respect transcrypt.crypt-dir if present. Default to crypt/ in Git dir
@@ -603,7 +603,7 @@ save_helper_hooks() {
 	cat <<-'EOF' >"$pre_commit_hook_installed"
 		#!/usr/bin/env bash
 		# Transcrypt pre-commit hook: fail if secret file in staging lacks the magic prefix "Salted" in B64
-		RELATIVE_GIT_DIR=$(git rev-parse --git-dir 2>/dev/null || printf '')
+		RELATIVE_GIT_DIR=$(git rev-parse --git-common-dir 2>/dev/null || printf '')
 		CRYPT_DIR=$(git config transcrypt.crypt-dir 2>/dev/null || printf '%s/crypt' "${RELATIVE_GIT_DIR}")
 		"${CRYPT_DIR}/transcrypt" pre_commit
 	EOF


### PR DESCRIPTION
running `git worktree add some-branch some-branch` in a transcrypted repository fails because the "common" config will point to a .git/worktrees/some-branch/transcrypt instead of .git/worktrees/transcrypt

this fix is half-baked because it then makes it impossible to activate transcrypt only inside 1 worktree, but overall it makes sense