### PR TITLE
handle --force when checking for incorrect password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ system, you must also run the `--upgrade` command in each repository:
 ### Changed
 
 - Improve check for incorrect password to avoid false report when transcrypt
-  init is run with --force in a repo containing dirty files (#196)
+  init is run with --force in a repo containing dirty files & add tests (#196)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ system, you must also run the `--upgrade` command in each repository:
 
 ## [Unreleased]
 
+### Changed
+
+- Improve check for incorrect password to avoid false report when transcrypt
+  init is run with --force in a repo containing dirty files (#196)
+
 ### Fixed
 
 - Fix pre-commit hook to use "fast" multi-threaded mode for Bash versions 5+ as

--- a/tests/_test_helper.bash
+++ b/tests/_test_helper.bash
@@ -43,6 +43,10 @@ function init_transcrypt {
   "$BATS_TEST_DIRNAME"/../transcrypt --cipher=aes-256-cbc --password='abc 123' --yes
 }
 
+function uninstall_transcrypt {
+  "$BATS_TEST_DIRNAME"/../transcrypt --uninstall --yes
+}
+
 function encrypt_named_file {
   filename="$1"
   content=$2

--- a/tests/test_init.bats
+++ b/tests/test_init.bats
@@ -168,3 +168,46 @@ SETUP_SKIP_INIT_TRANSCRYPT=1
   [ "${lines[0]}" = "==> sensitive_file <==" ]
   [ "${lines[1]}" = "$SECRET_CONTENT_ENC" ]
 }
+
+@test "crypt: warn on incorrect password as indicated by dirty files after init" {
+  init_transcrypt
+
+  SECRET_CONTENT="My secret content"
+  SECRET_CONTENT_ENC="U2FsdGVkX1/6ilR0PmJpAyCF7iG3+k4aBwbgVd48WaQXznsg42nXbQrlWsf/qiCg"
+
+  encrypt_named_file sensitive_file "$SECRET_CONTENT"
+
+  # Clear the password and reset the repo
+  uninstall_transcrypt
+  git reset --hard
+
+  # Init transcrypt with wrong password, command fails with error message
+  run "$BATS_TEST_DIRNAME"/../transcrypt --cipher=aes-256-cbc --password='WRONG' --yes
+  [ "$status" -eq 1 ]
+  [ "${lines[0]}" = "transcrypt: Unexpected new dirty files in the repository when configured by transcrypt, please check your password." ]
+}
+
+@test "crypt: warn on incorrect password as indicated by dirty files after init when forced" {
+  init_transcrypt
+
+  SECRET_CONTENT="My secret content"
+  SECRET_CONTENT_ENC="U2FsdGVkX1/6ilR0PmJpAyCF7iG3+k4aBwbgVd48WaQXznsg42nXbQrlWsf/qiCg"
+
+  encrypt_named_file sensitive_file "$SECRET_CONTENT"
+
+  # Clear the password and reset the repo
+  uninstall_transcrypt
+  git reset --hard
+
+  # Dirty repo before init, to check pre- and post-init dirty files counts
+  # work despite the pre-existing dirty file
+  echo "Dirty file" > dirty_file
+  git add dirty_file
+
+  # Force init transcrypt with wrong password, command fails with error message
+  run "$BATS_TEST_DIRNAME"/../transcrypt --force --cipher=aes-256-cbc --password='WRONG' --yes
+  [ "$status" -eq 1 ]
+  [ "${lines[0]}" = "transcrypt: Unexpected new dirty files in the repository when configured by transcrypt, please check your password." ]
+
+  rm dirty_file
+}

--- a/transcrypt
+++ b/transcrypt
@@ -1596,12 +1596,12 @@ elif [[ $cipher ]]; then
 	validate_cipher
 fi
 
-list_dirty_files() {
-	{ git diff-index --name-status HEAD -- || git diff-index --stat HEAD -- || git diff-index HEAD -- || true; } 2>/dev/null
+count_dirty_files() {
+	{ git diff-index --name-status HEAD -- || git diff-index --stat HEAD -- || git diff-index HEAD -- || true; } 2>/dev/null | grep $'\n' -c
 }
 
 # shellcheck disable=SC2155
-readonly GIT_DIRTY_FILES_BEFORE_INIT="$(list_dirty_files | grep $'\n' -c)"
+readonly GIT_DIRTY_FILES_BEFORE_INIT="$(count_dirty_files)"
 
 # perform function calls to configure transcrypt
 get_cipher
@@ -1629,7 +1629,7 @@ fi
 
 # check for newly modified (dirty) files after transcrypt configuration which could
 # indicate an incorrect password
-if [[ ${GIT_DIRTY_FILES_BEFORE_INIT} -lt $(list_dirty_files | grep $'\n' -c) ]]; then
+if [[ ${GIT_DIRTY_FILES_BEFORE_INIT} -lt $(count_dirty_files) ]]; then
 	die 1 'Unexpected new dirty files in the repository when configured by transcrypt%s, please check your password.\n' "$CONTEXT_DESCRIPTION"
 fi
 

--- a/transcrypt
+++ b/transcrypt
@@ -1596,6 +1596,13 @@ elif [[ $cipher ]]; then
 	validate_cipher
 fi
 
+list_dirty_files() {
+	{ git diff-index --name-status HEAD -- || git diff-index --stat HEAD -- || git diff-index HEAD -- || true; } 2>/dev/null
+}
+
+# shellcheck disable=SC2155
+readonly GIT_DIRTY_FILES_BEFORE_INIT="$(list_dirty_files | grep $'\n' -c)"
+
 # perform function calls to configure transcrypt
 get_cipher
 get_password
@@ -1620,12 +1627,10 @@ if [[ ! -f $GIT_ATTRIBUTES ]]; then
 	printf '#pattern  filter=crypt diff=crypt merge=crypt\n' >"$GIT_ATTRIBUTES"
 fi
 
-# check for modified (dirty) files after transcrypt configuration which could
+# check for newly modified (dirty) files after transcrypt configuration which could
 # indicate an incorrect password
-#
-# check if the repo is dirty
-if git status --porcelain 2>/dev/null | grep "^ M" >/dev/null; then
-	die 1 'Unexpected dirty files in the repository when configured by transcrypt%s, check your password.\n' "$CONTEXT_DESCRIPTION"
+if [[ ${GIT_DIRTY_FILES_BEFORE_INIT} -lt $(list_dirty_files | grep $'\n' -c) ]]; then
+	die 1 'Unexpected new dirty files in the repository when configured by transcrypt%s, please check your password.\n' "$CONTEXT_DESCRIPTION"
 fi
 
 printf 'The repository has been successfully configured by transcrypt%s.\n' "$CONTEXT_DESCRIPTION"


### PR DESCRIPTION
compare dirty before and after. see https://github.com/elasticdog/transcrypt/pull/195#issuecomment-2679272203

PS: switched to the same dirty check we have in run_safety_checks for consistency