### PR TITLE
ignore global core.attributesFile

### DIFF
--- a/transcrypt
+++ b/transcrypt
@@ -109,7 +109,7 @@ gather_repo_metadata() {
 
 	# the current git repository's gitattributes file
 	local CORE_ATTRIBUTES
-	CORE_ATTRIBUTES=$(git config --get --local --path core.attributesFile 2>/dev/null || git config --get --path core.attributesFile 2>/dev/null || printf '')
+	CORE_ATTRIBUTES=$(git config --get --local --path core.attributesFile 2>/dev/null || printf '')
 	if [[ $CORE_ATTRIBUTES ]]; then
 		readonly GIT_ATTRIBUTES=$CORE_ATTRIBUTES
 	elif [[ $IS_BARE == 'true' ]] || [[ $IS_VCSH == 'true' ]]; then


### PR DESCRIPTION
scenario: you have a global .gitattributes for settings crlf, text/binary, diff etc settings

then this is what you get

```
$ transcrypt --list-contexts                                                                                                                                                             default (no patterns in .gitattributes)
custom (no patterns in .gitattributes)
```

instead of

```
$ transcrypt --list-contexts                                                                                                                                                             default
custom
```

although the .gitattributes in the repo has the patterns defined

Point is: do we really support transcrypt globally? with custom contexts?
If we do, then we need to check all attributes files, not only the first one.

PS: on a different note, it also doesn't make sense (to me at least) that `--add=<pattern>` write to anything but a local gitattributes