### PR TITLE
Fix --uninstall/--upgrade crash when saved pre-commit-crypt hook is missing

### DIFF
--- a/tests/test_cleanup.bats
+++ b/tests/test_cleanup.bats
@@ -99,3 +99,18 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/6ilR0PmJpAyCF7iG3+k4aBwbgVd48WaQXznsg42nXbQrlWsf/
   run git show "$cached_plaintext_obj"
   [ "$status" -ne 0 ]
 }
+
+@test "cleanup: transcrypt --uninstall succeeds when saved pre-commit-crypt hook is missing" {
+  # Simulate a hook manager (e.g. husky) re-generating the hooks directory:
+  # transcrypt's saved hook copy is gone and a foreign pre-commit hook is in
+  # its place
+  rm .git/hooks/pre-commit-crypt
+  echo '#!/bin/sh' > .git/hooks/pre-commit
+
+  run ../transcrypt --uninstall --yes
+  [ "$status" -eq 0 ]
+  [[ "${output}" = *"WARNING: Cannot safely disable Git pre-commit hook"* ]]
+
+  # Confirm the foreign pre-commit hook was left alone
+  [ -f .git/hooks/pre-commit ]
+}

--- a/transcrypt
+++ b/transcrypt
@@ -902,7 +902,10 @@ uninstall_transcrypt() {
 		pre_commit_hook_installed="${GIT_HOOKS}/pre-commit-crypt"
 		if [[ -f "$pre_commit_hook" ]]; then
 			hook_md5=$("${openssl_path}" md5 -hex <"$pre_commit_hook")
-			installed_md5=$("${openssl_path}" md5 -hex <"$pre_commit_hook_installed")
+			installed_md5=''
+			if [[ -f "$pre_commit_hook_installed" ]]; then
+				installed_md5=$("${openssl_path}" md5 -hex <"$pre_commit_hook_installed")
+			fi
 			if [[ "$hook_md5" = "$installed_md5" ]]; then
 				rm "$pre_commit_hook"
 			else


### PR DESCRIPTION
`transcrypt --uninstall` (and `--upgrade`, which calls it) crashes when a `pre-commit` hook exists but transcrypt's saved `pre-commit-crypt` copy does not:

```
transcrypt: line 905: .husky/_/pre-commit-crypt: No such file or directory
```

The read on line 905 is unguarded, so `set -euo pipefail` aborts the script mid-uninstall.

Our use of husky for pre-commit hooks makes this state likely: `core.hooksPath` points at `.husky/_`, which husky re-generates on install — removing `pre-commit-crypt` — while installing its own `pre-commit` shim. But any missing saved copy triggers it.

The fix guards the read and falls through to the existing "Cannot safely disable Git pre-commit hook" warning — without the saved copy we can't tell whether the `pre-commit` hook is transcrypt's, so leave it alone and say so.

Includes a regression test (fails on `main`, passes with the fix). Full bats suite passes; `shellcheck` and `shfmt` clean.