### PR TITLE
Use read, rather than awk to address NUL byte handling issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ system, you must also run the `--upgrade` command in each repository:
 
 - Show warning message instead of crashing for `--uninstall` or `--upgrade`
   action when _transcrypt_'s saved pre-commit-crypt hook file is missing (#212)
+- List encrypted files using bash's null-delimited `read` instead of
+  `awk -v RS='\x00'`, which fails to list any files with awk builds that read
+  only the first record when the record separator is a null byte, such as the
+  Homebrew "one true awk" (#213, onetrueawk/awk#270)
 
 ## [2.3.2] - 2026-05-18
 

--- a/tests/_test_helper.bash
+++ b/tests/_test_helper.bash
@@ -14,6 +14,8 @@ function init_git_repo {
     # Tests will fail if name and email aren't set
     git config --local user.name "John Doe"
     git config --local user.email johndoe@example.com
+    # Tests require merge conflictStyle
+    git config --local merge.conflictStyle merge
     # Flag test git repo as 100% the test one, for safety before later removal
     touch "$BATS_TEST_DIRNAME"/.git/repo-for-transcrypt-bats-tests
   fi

--- a/transcrypt
+++ b/transcrypt
@@ -179,10 +179,19 @@ _list_encrypted_files() {
 	# https://git-scm.com/docs/git-config#Documentation/git-config.txt-corequotePath
 	git -c core.quotePath=false ls-files -z |
 		git -c core.quotePath=false check-attr filter -z --stdin 2>/dev/null |
-		# Split null-delimited list of filename + filter entries to be one line
-		# per file with space delimiters in that line by replacing every third
-		# null character with newline and the rest with a space
-		awk -v RS='\x00' 'NR % 3 == 0 {printf "%s\n", $0} NR % 3 != 0 {printf "%s ", $0}' |
+		# Convert the null-delimited "<path> NUL <attr> NUL <info> NUL" triples
+		# emitted by check-attr into one space-delimited line per file. We read
+		# the NUL-delimited fields directly in bash rather than using
+		# `awk -v RS='\x00'` because some awk builds (notably the Homebrew "one
+		# true awk", e.g. version 20260426) only read the first record when RS
+		# is a null byte. See #213.
+		{
+			while IFS= read -r -d '' path &&
+				IFS= read -r -d '' attr &&
+				IFS= read -r -d '' info; do
+				printf '%s %s %s\n' "$path" "$attr" "$info"
+			done
+		} |
 		{
 			# Only output names of encrypted files matching the context, either
 			# strictly (if $1 = "true") or loosely (if $1 is false or unset)


### PR DESCRIPTION
Fixes #213

From what I can tell, accomplishes the same as the awk usage without relying on the NUL byte behavior of particular versions of awk.

I didn't add any new tests because it relies on a specific version of awk to produce the issue, but all existing tests still pass aside from one, which failed prior to my change:

```
 ✗ merge: branches with encrypted file - line changes both branches, with conflicts
```