### PR TITLE
Run tests in parallel with isolated per-test tmp locations for speed

### DIFF
--- a/.github/workflows/run-bats-core-tests.yml
+++ b/.github/workflows/run-bats-core-tests.yml
@@ -66,5 +66,14 @@ jobs:
           mkdir -p /tmp/bats-core
           bash /tmp/bats-core-repo/install.sh /tmp/bats-core
 
+      # GNU parallel enables bats --jobs
+      - name: Install GNU parallel
+        run: |
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            brew install parallel
+          else
+            sudo apt-get update -qq && sudo apt-get install -y -qq parallel
+          fi
+
       - name: Run tests
-        run: /tmp/bats-core/bin/bats tests/
+        run: /tmp/bats-core/bin/bats --jobs 4 tests/

--- a/tests/_test_helper.bash
+++ b/tests/_test_helper.bash
@@ -1,52 +1,31 @@
+# Isolate tests from the developer's global and system git config, so
+# settings like merge.conflictstyle or commit.gpgsign cannot change test
+# behavior. Requires Git 2.32+.
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_CONFIG_SYSTEM=/dev/null
+
+# Absolute path to the script under test. Tests run inside per-test
+# temporary repos, so cwd-relative paths to the script would break.
+TRANSCRYPT="$BATS_TEST_DIRNAME/../transcrypt"
+
 function init_git_repo {
-  # Warn and do nothing if test dir envvar is unset
-  if [[ -z "$BATS_TEST_DIRNAME" ]]; then
-    echo "WARNING: Required envvar \$BATS_TEST_DIRNAME is unset"
-  # Warn and do nothing if test git repo path already exists
-  elif [[ -e "$BATS_TEST_DIRNAME/.git" ]]; then
-    echo "WARNING: Test repo already exists at $BATS_TEST_DIRNAME/.git"
-  else
-    # Configure "main" as the default branch name
-    git config --local init.defaultBranch main
-    # Initialise test git repo at the same path as the test files
-    git init "$BATS_TEST_DIRNAME"
-    git checkout -b main
-    # Tests will fail if name and email aren't set
-    git config --local user.name "John Doe"
-    git config --local user.email johndoe@example.com
-    # Tests require merge conflictStyle
-    git config --local merge.conflictStyle merge
-    # Flag test git repo as 100% the test one, for safety before later removal
-    touch "$BATS_TEST_DIRNAME"/.git/repo-for-transcrypt-bats-tests
-  fi
-}
-
-function nuke_git_repo {
-  # Warn and do nothing if test dir envvar is unset
-  if [[ -z "$BATS_TEST_DIRNAME" ]]; then
-    echo "WARNING: Required envvar \$BATS_TEST_DIRNAME is unset"
-  # Warn and do nothing if the test git repo is missing the flag file that
-  # ensures it *really* is the test one, as set by the 'init_git_repo' function
-  elif [[ ! -e "$BATS_TEST_DIRNAME/.git/repo-for-transcrypt-bats-tests" ]]; then
-    echo "WARNING: Aborting delete of non-test Git repo at $BATS_TEST_DIRNAME/.git"
-  else
-    # Forcibly delete the test git repo
-    rm -fR "$BATS_TEST_DIRNAME"/.git
-  fi
-}
-
-function cleanup_all {
-  nuke_git_repo
-  rm -f "$BATS_TEST_DIRNAME"/.gitattributes
-  rm -f "$BATS_TEST_DIRNAME"/sensitive_file
+  # Each test builds its repository in the bats-managed per-test temp
+  # dir, isolated from every other test so suites run under --jobs N.
+  # bats removes BATS_TEST_TMPDIR after teardown; no cleanup needed.
+  TEST_REPO="$BATS_TEST_TMPDIR/repo"
+  git init --quiet -b main "$TEST_REPO"
+  pushd "$TEST_REPO" >/dev/null || exit 1
+  # Tests will fail if name and email aren't set
+  git config --local user.name "John Doe"
+  git config --local user.email johndoe@example.com
 }
 
 function init_transcrypt {
-  "$BATS_TEST_DIRNAME"/../transcrypt --cipher=aes-256-cbc --password='abc 123' --yes
+  "$TRANSCRYPT" --cipher=aes-256-cbc --password='abc 123' --yes
 }
 
 function uninstall_transcrypt {
-  "$BATS_TEST_DIRNAME"/../transcrypt --uninstall --yes
+  "$TRANSCRYPT" --uninstall --yes
 }
 
 function encrypt_named_file {
@@ -66,16 +45,14 @@ function encrypt_named_file {
 }
 
 function setup {
-  pushd "$BATS_TEST_DIRNAME" || exit 1
   init_git_repo
-  if [[ ! "$SETUP_SKIP_INIT_TRANSCRYPT" ]]; then
+  if [[ ! "${SETUP_SKIP_INIT_TRANSCRYPT:-}" ]]; then
     init_transcrypt
   fi
 }
 
 function teardown {
-  cleanup_all
-  popd || exit 1
+  popd >/dev/null || exit 1
 }
 
 function check_repo_is_clean {

--- a/tests/test_cleanup.bats
+++ b/tests/test_cleanup.bats
@@ -19,8 +19,8 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/6ilR0PmJpAyCF7iG3+k4aBwbgVd48WaQXznsg42nXbQrlWsf/
   [[ "${output}" = *"+$SECRET_CONTENT" ]]  # Check last line of patch
 
   # Look up notes ref to cached plaintext
-  [ -f $BATS_TEST_DIRNAME/.git/refs/notes/textconv/crypt ]
-  cached_plaintext_obj=$(cat "$BATS_TEST_DIRNAME/.git/refs/notes/textconv/crypt")
+  [ -f .git/refs/notes/textconv/crypt ]
+  cached_plaintext_obj=$(cat ".git/refs/notes/textconv/crypt")
 
   # Confirm plaintext is cached
   run git show "$cached_plaintext_obj"
@@ -31,7 +31,7 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/6ilR0PmJpAyCF7iG3+k4aBwbgVd48WaQXznsg42nXbQrlWsf/
   git repack
 
   # Flush credentials
-  run ../transcrypt -f --yes
+  run $TRANSCRYPT -f --yes
   [ "$status" -eq 0 ]
 
   # Confirm working copy file is encrypted
@@ -46,7 +46,7 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/6ilR0PmJpAyCF7iG3+k4aBwbgVd48WaQXznsg42nXbQrlWsf/
   [[ "${output}" = *"+$SECRET_CONTENT_ENC" ]]  # Check last line of patch
 
   # Confirm plaintext cache ref was cleared
-  [ ! -e $BATS_TEST_DIRNAME/.git/refs/notes/textconv/crypt ]
+  [ ! -e .git/refs/notes/textconv/crypt ]
 
   # Confirm plaintext obj was truly cleared and is no longer visible
   run git show "$cached_plaintext_obj"
@@ -67,8 +67,8 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/6ilR0PmJpAyCF7iG3+k4aBwbgVd48WaQXznsg42nXbQrlWsf/
   [[ "${output}" = *"+$SECRET_CONTENT" ]]  # Check last line of patch
 
   # Look up notes ref to cached plaintext
-  [ -f $BATS_TEST_DIRNAME/.git/refs/notes/textconv/crypt ]
-  cached_plaintext_obj=$(cat "$BATS_TEST_DIRNAME/.git/refs/notes/textconv/crypt")
+  [ -f .git/refs/notes/textconv/crypt ]
+  cached_plaintext_obj=$(cat ".git/refs/notes/textconv/crypt")
 
   # Confirm plaintext is cached
   run git show "$cached_plaintext_obj"
@@ -79,7 +79,7 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/6ilR0PmJpAyCF7iG3+k4aBwbgVd48WaQXznsg42nXbQrlWsf/
   git repack
 
   # Uninstall
-  run ../transcrypt --uninstall --yes
+  run $TRANSCRYPT --uninstall --yes
   [ "$status" -eq 0 ]
 
   # Confirm working copy file remains unencrypted (per uninstall contract)
@@ -93,7 +93,7 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/6ilR0PmJpAyCF7iG3+k4aBwbgVd48WaQXznsg42nXbQrlWsf/
   [[ "${output}" = *"+$SECRET_CONTENT_ENC" ]]  # Check last line of patch
 
   # Confirm plaintext cache ref was cleared
-  [ ! -e $BATS_TEST_DIRNAME/.git/refs/notes/textconv/crypt ]
+  [ ! -e .git/refs/notes/textconv/crypt ]
 
   # Confirm plaintext obj was truly cleared and is no longer visible
   run git show "$cached_plaintext_obj"
@@ -107,7 +107,7 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/6ilR0PmJpAyCF7iG3+k4aBwbgVd48WaQXznsg42nXbQrlWsf/
   rm .git/hooks/pre-commit-crypt
   echo '#!/bin/sh' > .git/hooks/pre-commit
 
-  run ../transcrypt --uninstall --yes
+  run $TRANSCRYPT --uninstall --yes
   [ "$status" -eq 0 ]
   [[ "${output}" = *"WARNING: Cannot safely disable Git pre-commit hook"* ]]
 

--- a/tests/test_contexts.bats
+++ b/tests/test_contexts.bats
@@ -7,58 +7,51 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/6ilR0PmJpAyCF7iG3+k4aBwbgVd48WaQXznsg42nXbQrlWsf/
 SUPER_SECRET_CONTENT_ENC="U2FsdGVkX1+dAkIV/LAKXMmqjDNOGoOVK8Rmhw9tUnbR4dwBDglpkXIT3yzYBvoc"
 
 function setup {
-  pushd "$BATS_TEST_DIRNAME" || exit 1
   init_git_repo
   init_transcrypt
 
   # Init transcrypt with 'super-secret' context
-  "$BATS_TEST_DIRNAME"/../transcrypt --context=super-secret --cipher=aes-256-cbc --password=321cba --yes
-}
-
-function teardown {
-  cleanup_all
-  rm -f "$BATS_TEST_DIRNAME"/super_sensitive_file
-  popd || exit 1
+  $TRANSCRYPT --context=super-secret --cipher=aes-256-cbc --password=321cba --yes
 }
 
 @test "contexts: check validation of context names" {
   # Invalid context names
-  run ../transcrypt --context=-ab --cipher=aes-256-cbc --password=none --yes
+  run $TRANSCRYPT --context=-ab --cipher=aes-256-cbc --password=none --yes
   [ "$status" -ne 0 ]
-  run ../transcrypt --context=1ab --cipher=aes-256-cbc --password=none --yes
+  run $TRANSCRYPT --context=1ab --cipher=aes-256-cbc --password=none --yes
   [ "$status" -ne 0 ]
-  run ../transcrypt --context=a--b --cipher=aes-256-cbc --password=none --yes
+  run $TRANSCRYPT --context=a--b --cipher=aes-256-cbc --password=none --yes
   [ "$status" -ne 0 ]
-  run ../transcrypt --context=a- --cipher=aes-256-cbc --password=none --yes
+  run $TRANSCRYPT --context=a- --cipher=aes-256-cbc --password=none --yes
   [ "$status" -ne 0 ]
-  run ../transcrypt --context=A --cipher=aes-256-cbc --password=none --yes
+  run $TRANSCRYPT --context=A --cipher=aes-256-cbc --password=none --yes
   [ "$status" -ne 0 ]
-  run ../transcrypt --context=aB --cipher=aes-256-cbc --password=none --yes
+  run $TRANSCRYPT --context=aB --cipher=aes-256-cbc --password=none --yes
   [ "$status" -ne 0 ]
-  run ../transcrypt --context=a-B --cipher=aes-256-cbc --password=none --yes
+  run $TRANSCRYPT --context=a-B --cipher=aes-256-cbc --password=none --yes
   [ "$status" -ne 0 ]
 
   # Valid context names
-  run ../transcrypt --context=ab --cipher=aes-256-cbc --password=none --yes
+  run $TRANSCRYPT --context=ab --cipher=aes-256-cbc --password=none --yes
   [ "$status" -eq 0 ]
-  run ../transcrypt --context=a1 --cipher=aes-256-cbc --password=none --yes
+  run $TRANSCRYPT --context=a1 --cipher=aes-256-cbc --password=none --yes
   [ "$status" -eq 0 ]
-  run ../transcrypt --context=a-b --cipher=aes-256-cbc --password=none --yes
+  run $TRANSCRYPT --context=a-b --cipher=aes-256-cbc --password=none --yes
   [ "$status" -eq 0 ]
-  run ../transcrypt --context=a-1 --cipher=aes-256-cbc --password=none --yes
+  run $TRANSCRYPT --context=a-1 --cipher=aes-256-cbc --password=none --yes
   [ "$status" -eq 0 ]
-  run ../transcrypt --context=a-b-c --cipher=aes-256-cbc --password=none --yes
+  run $TRANSCRYPT --context=a-b-c --cipher=aes-256-cbc --password=none --yes
   [ "$status" -eq 0 ]
-  run ../transcrypt --context=a-1-c --cipher=aes-256-cbc --password=none --yes
+  run $TRANSCRYPT --context=a-1-c --cipher=aes-256-cbc --password=none --yes
   [ "$status" -eq 0 ]
-  run ../transcrypt --context=a-b-c-d --cipher=aes-256-cbc --password=none --yes
+  run $TRANSCRYPT --context=a-b-c-d --cipher=aes-256-cbc --password=none --yes
   [ "$status" -eq 0 ]
-  run ../transcrypt --context=a-1-c-d-2 --cipher=aes-256-cbc --password=none --yes
+  run $TRANSCRYPT --context=a-1-c-d-2 --cipher=aes-256-cbc --password=none --yes
   [ "$status" -eq 0 ]
 }
 
 @test "contexts: check git config for 'super-secret' context" {
-  VERSION=$(../transcrypt -v | awk '{print $2}')
+  VERSION=$($TRANSCRYPT -v | awk '{print $2}')
 
   [[ $(git config --get transcrypt.version) = "$VERSION" ]]
   [[ $(git config --get transcrypt.super-secret.cipher) = "aes-256-cbc" ]]
@@ -80,9 +73,9 @@ function teardown {
 }
 
 @test "init: show extra context details in --display" {
-  VERSION=$(../transcrypt -v | awk '{print $2}')
+  VERSION=$($TRANSCRYPT -v | awk '{print $2}')
 
-  run ../transcrypt -C super-secret --display
+  run $TRANSCRYPT -C super-secret --display
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = "The current repository was configured using transcrypt version $VERSION" ]
   [ "${lines[1]}" = "and has the following configuration for context 'super-secret':" ]
@@ -96,12 +89,12 @@ function teardown {
 
 @test "contexts: cannot re-init an existing context, fails with error message" {
   # Cannot re-init 'default' context
-  run ../transcrypt --cipher=aes-256-cbc --password='abc 123' --yes
+  run $TRANSCRYPT --cipher=aes-256-cbc --password='abc 123' --yes
   [ "$status" -ne 0 ]
   [ "${lines[0]}" = "transcrypt: the current repository is already configured; see 'transcrypt --display'" ]
 
   # Cannot re-init a named context
-  run ../transcrypt --context=super-secret --cipher=aes-256-cbc --password=321cba --yes
+  run $TRANSCRYPT --context=super-secret --cipher=aes-256-cbc --password=321cba --yes
   [ "$status" -ne 0 ]
   [ "${lines[0]}" = "transcrypt: the current repository is already configured for context 'super-secret'; see 'transcrypt --context=super-secret --display'" ]
 }
@@ -118,7 +111,7 @@ function teardown {
 
 @test "contexts: confirm --list-contexts lists configured contexts not yet in .gitattributes" {
   # Confirm .gitattributes is not yet configured for multiple contexts
-  run ../transcrypt --list-contexts
+  run $TRANSCRYPT --list-contexts
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = 'default (no patterns in .gitattributes)' ]
   [ "${lines[1]}" = 'super-secret (no patterns in .gitattributes)' ]
@@ -129,7 +122,7 @@ function teardown {
   encrypt_named_file super_sensitive_file "$SECRET_CONTENT" "super-secret"
 
   # Confirm .gitattributes is configured for multiple contexts
-  run ../transcrypt --list-contexts
+  run $TRANSCRYPT --list-contexts
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = 'default' ]
   [ "${lines[1]}" = 'super-secret' ]
@@ -140,24 +133,24 @@ function teardown {
   encrypt_named_file super_sensitive_file "$SECRET_CONTENT" "super-secret"
 
   # Remove all transcrypt config, including contexts
-  ../transcrypt --uninstall --yes
+  $TRANSCRYPT --uninstall --yes
 
   # Don't list contexts when none are known
   echo > .gitattributes
-  run ../transcrypt --list-contexts
+  run $TRANSCRYPT --list-contexts
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = '' ]
 
   # List just super-secret context from .gitattributes
   echo  '"super_sensitive_file" filter=crypt-super-secret diff=crypt-super-secret merge=crypt-super-secret' > .gitattributes
-  run ../transcrypt --list-contexts
+  run $TRANSCRYPT --list-contexts
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = 'super-secret (not initialised)' ]
   [ "${lines[1]}" = '' ]
 
   # List just default context from .gitattributes
   echo  '"sensitive_file" filter=crypt diff=crypt merge=crypt' > .gitattributes
-  run ../transcrypt --list-contexts
+  run $TRANSCRYPT --list-contexts
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = 'default (not initialised)' ]
   [ "${lines[1]}" = '' ]
@@ -205,12 +198,12 @@ function teardown {
   encrypt_named_file sensitive_file "$SECRET_CONTENT"
   encrypt_named_file super_sensitive_file "$SECRET_CONTENT" "super-secret"
 
-  run ../transcrypt --show-raw sensitive_file
+  run $TRANSCRYPT --show-raw sensitive_file
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = "==> sensitive_file <==" ]
   [ "${lines[1]}" = "$SECRET_CONTENT_ENC" ]
 
-  run ../transcrypt --show-raw super_sensitive_file
+  run $TRANSCRYPT --show-raw super_sensitive_file
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = "==> super_sensitive_file <==" ]
   [ "${lines[1]}" = "$SUPER_SECRET_CONTENT_ENC" ]
@@ -250,7 +243,7 @@ function teardown {
   encrypt_named_file sensitive_file "$SECRET_CONTENT"
   encrypt_named_file super_sensitive_file "$SECRET_CONTENT" "super-secret"
 
-  run ../transcrypt --list
+  run $TRANSCRYPT --list
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = "sensitive_file" ]
   [ "${lines[1]}" = "super_sensitive_file" ]
@@ -261,7 +254,7 @@ function teardown {
   encrypt_named_file sensitive_file "$SECRET_CONTENT"
   encrypt_named_file super_sensitive_file "$SECRET_CONTENT" "super-secret"
 
-  run ../transcrypt --uninstall --yes
+  run $TRANSCRYPT --uninstall --yes
   [ "$status" -eq 0 ]
 
   run cat sensitive_file
@@ -283,7 +276,7 @@ function teardown {
   encrypt_named_file sensitive_file "$SECRET_CONTENT"
   encrypt_named_file super_sensitive_file "$SECRET_CONTENT" "super-secret"
 
-  ../transcrypt --uninstall --yes
+  $TRANSCRYPT --uninstall --yes
 
   git reset --hard
   check_repo_is_clean
@@ -303,7 +296,7 @@ function teardown {
   # Init transcrypt with encrypted files then reset to be like a new clone
   encrypt_named_file sensitive_file "$SECRET_CONTENT"
   encrypt_named_file super_sensitive_file "$SECRET_CONTENT" "super-secret"
-  ../transcrypt --uninstall --yes
+  $TRANSCRYPT --uninstall --yes
   git reset --hard
   check_repo_is_clean
 
@@ -314,14 +307,14 @@ function teardown {
   [ "${lines[0]}" = "$SUPER_SECRET_CONTENT_ENC" ]
 
   # Confirm .gitattributes is configured for contexts, but Git is not
-  run ../transcrypt --list-contexts
+  run $TRANSCRYPT --list-contexts
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = 'default (not initialised)' ]
   [ "${lines[1]}" = 'super-secret (not initialised)' ]
 
   # Re-init only super-secret context: its files are decrypted, not default context
-  ../transcrypt --context=super-secret --cipher=aes-256-cbc --password=321cba --yes
-  run ../transcrypt --list-contexts
+  $TRANSCRYPT --context=super-secret --cipher=aes-256-cbc --password=321cba --yes
+  run $TRANSCRYPT --list-contexts
   [ "${lines[0]}" = 'default (not initialised)' ]
   [ "${lines[1]}" = 'super-secret' ]
   run cat super_sensitive_file
@@ -330,13 +323,13 @@ function teardown {
   [ "${lines[0]}" = "$SECRET_CONTENT_ENC" ]
 
   # Reset again
-  ../transcrypt --uninstall --yes
+  $TRANSCRYPT --uninstall --yes
   git reset --hard
   check_repo_is_clean
 
   # Re-init only default context: its files are decrypted, not super-secret context
-  ../transcrypt --cipher=aes-256-cbc --password='abc 123' --yes
-  run ../transcrypt --list-contexts
+  $TRANSCRYPT --cipher=aes-256-cbc --password='abc 123' --yes
+  run $TRANSCRYPT --list-contexts
   [ "${lines[0]}" = 'default' ]
   [ "${lines[1]}" = 'super-secret (not initialised)' ]
   run cat sensitive_file
@@ -345,13 +338,13 @@ function teardown {
   [ "${lines[0]}" = "$SUPER_SECRET_CONTENT_ENC" ]
 
   # Reset again
-  ../transcrypt --uninstall --yes
+  $TRANSCRYPT --uninstall --yes
   git reset --hard
   check_repo_is_clean
 
   # Re-init super-secret then default contexts, to confirm safety check permits this
-  ../transcrypt --context=super-secret --cipher=aes-256-cbc --password=321cba --yes
-  ../transcrypt --cipher=aes-256-cbc --password='abc 123' --yes
+  $TRANSCRYPT --context=super-secret --cipher=aes-256-cbc --password=321cba --yes
+  $TRANSCRYPT --cipher=aes-256-cbc --password='abc 123' --yes
 }
 
 @test "contexts: --upgrade retains all context configs" {
@@ -361,15 +354,15 @@ function teardown {
 
   # We use context names without warning notes as a surrogate for checking
   # that the super-secret context is configured and in .gitattributes
-  run ../transcrypt --list-contexts
+  run $TRANSCRYPT --list-contexts
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = 'default' ]
   [ "${lines[1]}" = 'super-secret' ]
 
   # Upgrade removes and *should* re-create config for all contexts
-  run ../transcrypt --upgrade --yes
+  run $TRANSCRYPT --upgrade --yes
 
-  run ../transcrypt --list-contexts
+  run $TRANSCRYPT --list-contexts
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = 'default' ]
   [ "${lines[1]}" = 'super-secret' ]

--- a/tests/test_crypt.bats
+++ b/tests/test_crypt.bats
@@ -39,7 +39,7 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/6ilR0PmJpAyCF7iG3+k4aBwbgVd48WaQXznsg42nXbQrlWsf/
 
 @test "crypt: transcrypt --show-raw shows encrypted content" {
   encrypt_named_file sensitive_file "$SECRET_CONTENT"
-  run ../transcrypt --show-raw sensitive_file
+  run $TRANSCRYPT --show-raw sensitive_file
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = "==> sensitive_file <==" ]
   [ "${lines[1]}" = "$SECRET_CONTENT_ENC" ]
@@ -56,7 +56,7 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/6ilR0PmJpAyCF7iG3+k4aBwbgVd48WaQXznsg42nXbQrlWsf/
 @test "crypt: transcrypt --list lists encrypted file" {
   encrypt_named_file sensitive_file "$SECRET_CONTENT"
 
-  run ../transcrypt --list
+  run $TRANSCRYPT --list
   [ "$status" -eq 0 ]
   [[ "${output}" = *"sensitive_file" ]]
 }
@@ -64,7 +64,7 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/6ilR0PmJpAyCF7iG3+k4aBwbgVd48WaQXznsg42nXbQrlWsf/
 @test "crypt: transcrypt --uninstall leaves decrypted file and repo dirty" {
   encrypt_named_file sensitive_file "$SECRET_CONTENT"
 
-  run ../transcrypt --uninstall --yes
+  run $TRANSCRYPT --uninstall --yes
   [ "$status" -eq 0 ]
 
   run cat sensitive_file
@@ -81,7 +81,7 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/6ilR0PmJpAyCF7iG3+k4aBwbgVd48WaQXznsg42nXbQrlWsf/
 @test "crypt: git reset after uninstall leaves encrypted file" {
   encrypt_named_file sensitive_file "$SECRET_CONTENT"
 
-  "$BATS_TEST_DIRNAME"/../transcrypt --uninstall --yes
+  $TRANSCRYPT --uninstall --yes
 
   git reset --hard
   check_repo_is_clean
@@ -117,7 +117,7 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/6ilR0PmJpAyCF7iG3+k4aBwbgVd48WaQXznsg42nXbQrlWsf/
   [ "${lines[0]}" = "$SECRET_CONTENT_ENC" ]
 
   # transcrypt --show-raw shows encrypted content
-  run ../transcrypt --show-raw "$FILENAME"
+  run $TRANSCRYPT --show-raw "$FILENAME"
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = "==> $FILENAME <==" ]
   [ "${lines[1]}" = "$SECRET_CONTENT_ENC" ]
@@ -128,7 +128,7 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/6ilR0PmJpAyCF7iG3+k4aBwbgVd48WaQXznsg42nXbQrlWsf/
   [[ "${output}" = *"$FILENAME" ]]
 
   # transcrypt --list lists encrypted file"
-  run ../transcrypt --list
+  run $TRANSCRYPT --list
   [ "$status" -eq 0 ]
   [[ "${output}" = *"$FILENAME" ]]
 
@@ -162,7 +162,7 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/6ilR0PmJpAyCF7iG3+k4aBwbgVd48WaQXznsg42nXbQrlWsf/
   [[ "${output}" = *"$FILENAME" ]]
 
   # transcrypt --list lists encrypted file"
-  run ../transcrypt --list
+  run $TRANSCRYPT --list
   [ "$status" -eq 0 ]
   [[ "${output}" = *"$FILENAME" ]]
 
@@ -188,7 +188,7 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/6ilR0PmJpAyCF7iG3+k4aBwbgVd48WaQXznsg42nXbQrlWsf/
   [ "${lines[0]}" = "$SECRET_CONTENT_ENC" ]
 
   # transcrypt --show-raw shows encrypted content
-  run ../transcrypt --show-raw "$FILENAME"
+  run $TRANSCRYPT --show-raw "$FILENAME"
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = "==> $FILENAME <==" ]
   [ "${lines[1]}" = "$SECRET_CONTENT_ENC" ]
@@ -199,7 +199,7 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/6ilR0PmJpAyCF7iG3+k4aBwbgVd48WaQXznsg42nXbQrlWsf/
   [[ "${output}" = *"$FILENAME" ]]
 
   # transcrypt --list lists encrypted file"
-  run ../transcrypt --list
+  run $TRANSCRYPT --list
   [ "$status" -eq 0 ]
   [[ "${output}" = *"$FILENAME" ]]
 
@@ -222,7 +222,7 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/6ilR0PmJpAyCF7iG3+k4aBwbgVd48WaQXznsg42nXbQrlWsf/
   [ "${lines[0]}" = "$SECRET_CONTENT_ENC" ]
 
   # transcrypt --show-raw shows encrypted content
-  run ../transcrypt --show-raw "$FILENAME"
+  run $TRANSCRYPT --show-raw "$FILENAME"
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = "==> $FILENAME <==" ]
   [ "${lines[1]}" = "$SECRET_CONTENT_ENC" ]
@@ -233,7 +233,7 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/6ilR0PmJpAyCF7iG3+k4aBwbgVd48WaQXznsg42nXbQrlWsf/
   [[ "${output}" = *"$FILENAME" ]]
 
   # transcrypt --list lists encrypted file"
-  run ../transcrypt --list
+  run $TRANSCRYPT --list
   [ "$status" -eq 0 ]
   [[ "${output}" = *"$FILENAME" ]]
 
@@ -258,8 +258,8 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/6ilR0PmJpAyCF7iG3+k4aBwbgVd48WaQXznsg42nXbQrlWsf/
   [[ "${lines[2]}" = "config/*.json  filter=crypt diff=crypt merge=crypt" ]]
 
   # add patterns 3 & 4 via `transcrypt --add`
-  "$BATS_TEST_DIRNAME"/../transcrypt --add pattern2
-  "$BATS_TEST_DIRNAME"/../transcrypt --add=*.secret
+  $TRANSCRYPT --add pattern2
+  $TRANSCRYPT --add=*.secret
   run cat .gitattributes
   [[ "$status" -eq 0 ]]
   [[ "${#lines[@]}" = "5" ]]
@@ -281,7 +281,7 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/6ilR0PmJpAyCF7iG3+k4aBwbgVd48WaQXznsg42nXbQrlWsf/
 }
 
 @test "crypt: transcrypt --upgrade applies new merge driver" {
-  VERSION=$("$BATS_TEST_DIRNAME"/../transcrypt -v | awk '{print $2}')
+  VERSION=$($TRANSCRYPT -v | awk '{print $2}')
 
   encrypt_named_file sensitive_file "$SECRET_CONTENT"
 
@@ -312,7 +312,7 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/6ilR0PmJpAyCF7iG3+k4aBwbgVd48WaQXznsg42nXbQrlWsf/
   [ "${lines[0]}" = "$SECRET_CONTENT" ]
 
   # Perform re-install
-  run ../transcrypt --upgrade --yes
+  run $TRANSCRYPT --upgrade --yes
   [ "$status" -eq 0 ]
 
   run git config --get --local transcrypt.version
@@ -341,7 +341,7 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/6ilR0PmJpAyCF7iG3+k4aBwbgVd48WaQXznsg42nXbQrlWsf/
 @test "crypt: transcrypt --force handles files missing from working copy" {
   encrypt_named_file sensitive_file "$SECRET_CONTENT"
 
-  "$BATS_TEST_DIRNAME"/../transcrypt --uninstall --yes
+  $TRANSCRYPT --uninstall --yes
 
   # Reset repo to restore .gitattributes file
   git reset --hard
@@ -350,7 +350,7 @@ SECRET_CONTENT_ENC="U2FsdGVkX1/6ilR0PmJpAyCF7iG3+k4aBwbgVd48WaQXznsg42nXbQrlWsf/
   rm sensitive_file
 
   # Re-init with --force should check out deleted secret file
-  ../transcrypt --force --cipher=aes-256-cbc --password='abc 123' --yes
+  $TRANSCRYPT --force --cipher=aes-256-cbc --password='abc 123' --yes
 
   # Check sensitive_file is present and decrypted
   run cat sensitive_file

--- a/tests/test_init.bats
+++ b/tests/test_init.bats
@@ -9,7 +9,7 @@ SETUP_SKIP_INIT_TRANSCRYPT=1
 
 @test "init: works at all" {
   # Use literal command not function to confirm command works at least once
-  run ../transcrypt --cipher=aes-256-cbc --password='abc 123' --yes
+  run $TRANSCRYPT --cipher=aes-256-cbc --password='abc 123' --yes
   [ "$status" -eq 0 ]
   [[ "${output}" = *"The repository has been successfully configured by transcrypt."* ]]
 }
@@ -29,7 +29,7 @@ SETUP_SKIP_INIT_TRANSCRYPT=1
 
 @test "init: applies git config" {
   init_transcrypt
-  VERSION=$(../transcrypt -v | awk '{print $2}')
+  VERSION=$($TRANSCRYPT -v | awk '{print $2}')
 
   [ "$(git config --get transcrypt.version)" = "$VERSION" ]
   [ "$(git config --get transcrypt.cipher)" = "aes-256-cbc" ]
@@ -56,9 +56,9 @@ SETUP_SKIP_INIT_TRANSCRYPT=1
 
 @test "init: show details for --display" {
   init_transcrypt
-  VERSION=$(../transcrypt -v | awk '{print $2}')
+  VERSION=$($TRANSCRYPT -v | awk '{print $2}')
 
-  run ../transcrypt --display
+  run $TRANSCRYPT --display
   [ "$status" -eq 0 ]
   [[ "${output}" = *"The current repository was configured using transcrypt version $VERSION"* ]]
   [[ "${output}" = *"  CIPHER:   aes-256-cbc"* ]]
@@ -68,9 +68,9 @@ SETUP_SKIP_INIT_TRANSCRYPT=1
 
 @test "init: show details for -d" {
   init_transcrypt
-  VERSION=$(../transcrypt -v | awk '{print $2}')
+  VERSION=$($TRANSCRYPT -v | awk '{print $2}')
 
-  run ../transcrypt -d
+  run $TRANSCRYPT -d
   [ "$status" -eq 0 ]
   [[ "${output}" = *"The current repository was configured using transcrypt version $VERSION"* ]]
   [[ "${output}" = *"  CIPHER:   aes-256-cbc"* ]]
@@ -86,8 +86,8 @@ SETUP_SKIP_INIT_TRANSCRYPT=1
   [ -d .git/myhooks ]
   [ -f .git/myhooks/pre-commit ]
 
-  VERSION=$(../transcrypt -v | awk '{print $2}')
-  run ../transcrypt --display
+  VERSION=$($TRANSCRYPT -v | awk '{print $2}')
+  run $TRANSCRYPT --display
   [ "$status" -eq 0 ]
   [[ "${output}" = *"The current repository was configured using transcrypt version $VERSION"* ]]
   [[ "${output}" = *"  CIPHER:   aes-256-cbc"* ]]
@@ -101,7 +101,7 @@ SETUP_SKIP_INIT_TRANSCRYPT=1
 }
 
 @test "init: --set-openssl-path is applied during init" {
-  run ../transcrypt --cipher=aes-256-cbc --password='abc 123' --yes --set-openssl-path=/test/path
+  run $TRANSCRYPT --cipher=aes-256-cbc --password='abc 123' --yes --set-openssl-path=/test/path
   [ "$(git config --get transcrypt.openssl-path)" = "/test/path" ]
 }
 
@@ -112,7 +112,7 @@ SETUP_SKIP_INIT_TRANSCRYPT=1
   # Set openssl path
   FULL_OPENSSL_PATH=$(which openssl)
 
-  run ../transcrypt --upgrade --yes --set-openssl-path="$FULL_OPENSSL_PATH"
+  run $TRANSCRYPT --upgrade --yes --set-openssl-path="$FULL_OPENSSL_PATH"
   [ "$(git config --get transcrypt.openssl-path)" = "$FULL_OPENSSL_PATH" ]
   [ ! "$(git config --get transcrypt.openssl-path)" = 'openssl' ]
 }
@@ -123,10 +123,10 @@ SETUP_SKIP_INIT_TRANSCRYPT=1
 
   # Set openssl path
   FULL_OPENSSL_PATH=$(which openssl)
-  run ../transcrypt --set-openssl-path="$FULL_OPENSSL_PATH"'' --yes
+  run $TRANSCRYPT --set-openssl-path="$FULL_OPENSSL_PATH"'' --yes
 
   # Retain transcrypt.openssl-path config setting on upgrade
-  run ../transcrypt --upgrade --yes
+  run $TRANSCRYPT --upgrade --yes
   [ "$(git config --get transcrypt.openssl-path)" = "$FULL_OPENSSL_PATH" ]
   [ ! "$(git config --get transcrypt.openssl-path)" = 'openssl' ]
 }
@@ -138,12 +138,12 @@ SETUP_SKIP_INIT_TRANSCRYPT=1
   # GNU/Linux.
   echo '"sensitive_file" filter=crypt diff=crypt merge=crypt' > attributes_target
   ln -sf attributes_target attributes_link
-  git config core.attributesFile "$BATS_TEST_DIRNAME/attributes_link"
+  git config core.attributesFile "$PWD/attributes_link"
 
   init_transcrypt
   [ -L attributes_link ]
 
-  run ../transcrypt --uninstall --yes
+  run $TRANSCRYPT --uninstall --yes
   [ "$status" -eq 0 ]
 
   # The symlink must be preserved, not replaced by a regular file...
@@ -160,11 +160,11 @@ SETUP_SKIP_INIT_TRANSCRYPT=1
   # likewise edit through the symlink rather than over it.
   echo '"sensitive_file" filter=crypt diff=crypt' > attributes_target
   ln -sf attributes_target attributes_link
-  git config core.attributesFile "$BATS_TEST_DIRNAME/attributes_link"
+  git config core.attributesFile "$PWD/attributes_link"
 
   init_transcrypt
 
-  run ../transcrypt --upgrade --yes
+  run $TRANSCRYPT --upgrade --yes
   [ "$status" -eq 0 ]
 
   # The symlink must be preserved, not replaced by a regular file...
@@ -178,26 +178,26 @@ SETUP_SKIP_INIT_TRANSCRYPT=1
 
 @test "init: transcrypt.crypt-dir config setting is applied during init" {
   # Clear tmp crypt/ directory, in case junk was left there from prior test runs
-  rm -fR /tmp/crypt/
+  rm -fR $BATS_TEST_TMPDIR/crypt/
 
   # Set a custom location for the crypt/ directory
-  git config transcrypt.crypt-dir /tmp/crypt
+  git config transcrypt.crypt-dir $BATS_TEST_TMPDIR/crypt
 
   init_transcrypt
 
   # Confirm crypt/ directory is populated in custom location
   [ ! -d .git/crypt ]
   [ ! -f .git/crypt/transcrypt ]
-  [ -d /tmp/crypt ]
-  [ -f /tmp/crypt/transcrypt ]
+  [ -d $BATS_TEST_TMPDIR/crypt ]
+  [ -f $BATS_TEST_TMPDIR/crypt/transcrypt ]
 }
 
 @test "crypt: transcrypt.crypt-dir config setting produces working scripts" {
   # Clear tmp crypt/ directory, in case junk was left there from prior test runs
-  rm -fR /tmp/crypt/
+  rm -fR $BATS_TEST_TMPDIR/crypt/
 
   # Set a custom location for the crypt/ directory
-  git config transcrypt.crypt-dir /tmp/crypt
+  git config transcrypt.crypt-dir $BATS_TEST_TMPDIR/crypt
 
   init_transcrypt
 
@@ -210,7 +210,7 @@ SETUP_SKIP_INIT_TRANSCRYPT=1
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = "$SECRET_CONTENT" ]
 
-  run ../transcrypt --show-raw sensitive_file
+  run $TRANSCRYPT --show-raw sensitive_file
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = "==> sensitive_file <==" ]
   [ "${lines[1]}" = "$SECRET_CONTENT_ENC" ]
@@ -229,7 +229,7 @@ SETUP_SKIP_INIT_TRANSCRYPT=1
   git reset --hard
 
   # Init transcrypt with wrong password, command fails with error message
-  run "$BATS_TEST_DIRNAME"/../transcrypt --cipher=aes-256-cbc --password='WRONG' --yes
+  run $TRANSCRYPT --cipher=aes-256-cbc --password='WRONG' --yes
   [ "$status" -eq 1 ]
   [ "${lines[0]}" = "transcrypt: Unexpected new dirty files in the repository when configured by transcrypt, please check your password." ]
 }
@@ -252,7 +252,7 @@ SETUP_SKIP_INIT_TRANSCRYPT=1
   git add dirty_file
 
   # Force init transcrypt with wrong password, command fails with error message
-  run "$BATS_TEST_DIRNAME"/../transcrypt --force --cipher=aes-256-cbc --password='WRONG' --yes
+  run $TRANSCRYPT --force --cipher=aes-256-cbc --password='WRONG' --yes
   [ "$status" -eq 1 ]
   [ "${lines[0]}" = "transcrypt: Unexpected new dirty files in the repository when configured by transcrypt, please check your password." ]
 

--- a/tests/test_not_inited.bats
+++ b/tests/test_not_inited.bats
@@ -12,29 +12,29 @@ SETUP_SKIP_INIT_TRANSCRYPT=1
 # Operations that should work in a repo not yet initialised
 
 @test "not inited: show help for --help" {
-  run ../transcrypt --help
+  run $TRANSCRYPT --help
   [ "${lines[1]}" = "     transcrypt -- transparently encrypt files within a git repository" ]
 }
 
 @test "not inited: show help for -h" {
-  run ../transcrypt -h
+  run $TRANSCRYPT -h
   [ "${lines[1]}" = "     transcrypt -- transparently encrypt files within a git repository" ]
 }
 
 @test "not inited: show version for --version" {
-  VERSION=$(../transcrypt -v | awk '{print $2}')
-  run ../transcrypt --version
+  VERSION=$($TRANSCRYPT -v | awk '{print $2}')
+  run $TRANSCRYPT --version
   [ "${lines[0]}" = "transcrypt $VERSION" ]
 }
 
 @test "not inited: show version for -v" {
-  VERSION=$(../transcrypt -v | awk '{print $2}')
-  run ../transcrypt -v
+  VERSION=$($TRANSCRYPT -v | awk '{print $2}')
+  run $TRANSCRYPT -v
   [ "${lines[0]}" = "transcrypt $VERSION" ]
 }
 
 @test "not inited: no files listed for --list" {
-  run ../transcrypt --list
+  run $TRANSCRYPT --list
   if [[ "${output}" = *"WARNING"* ]]; then
     [ "${lines[0]}" = "*** WARNING : deprecated key derivation used." ]
     [ "${lines[1]}" = "Using -iter or -pbkdf2 would be better." ]
@@ -44,7 +44,7 @@ SETUP_SKIP_INIT_TRANSCRYPT=1
 }
 
 @test "not inited: no files listed for -l" {
-  run ../transcrypt -l
+  run $TRANSCRYPT -l
   if [[ "${output}" = *"WARNING"* ]]; then
     [ "${lines[0]}" = "*** WARNING : deprecated key derivation used." ]
     [ "${lines[1]}" = "Using -iter or -pbkdf2 would be better." ]
@@ -57,32 +57,32 @@ SETUP_SKIP_INIT_TRANSCRYPT=1
 # Operations that should not work in a repo not yet initialised
 
 @test "not inited: error on --display" {
-  run ../transcrypt --display
+  run $TRANSCRYPT --display
   [ "$status" -ne 0 ]
   [[ "${output}" = *"transcrypt: the current repository is not configured"* ]]
 }
 
 @test "not inited: error on -d" {
-  run ../transcrypt -d
+  run $TRANSCRYPT -d
   [ "$status" -ne 0 ]
   [[ "${output}" = *"transcrypt: the current repository is not configured"* ]]
 }
 
 @test "not inited: error on --uninstall" {
-  run ../transcrypt --uninstall
+  run $TRANSCRYPT --uninstall
   [ "$status" -ne 0 ]
   [[ "${output}" = *"transcrypt: the current repository is not configured"* ]]
 }
 
 @test "not inited: error on -u" {
-  run ../transcrypt -u
+  run $TRANSCRYPT -u
   [ "$status" -ne 0 ]
   [[ "${output}" = *"transcrypt: the current repository is not configured"* ]]
 }
 
 
 @test "not inited: error on --upgrade" {
-  run ../transcrypt --upgrade
+  run $TRANSCRYPT --upgrade
   [ "$status" -ne 0 ]
   [[ "${output}" = *"transcrypt: the current repository is not configured"* ]]
 }

--- a/tests/test_pre_commit.bats
+++ b/tests/test_pre_commit.bats
@@ -67,12 +67,12 @@ load "$BATS_TEST_DIRNAME/_test_helper.bash"
 
 @test "pre-commit: warn and don't clobber existing pre-commit hook on init" {
   # Uninstall pre-existing transcrypt config from setup()
-  run "$BATS_TEST_DIRNAME"/../transcrypt --uninstall --yes
+  run $TRANSCRYPT --uninstall --yes
 
   # Create a pre-existing pre-commit hook
   touch .git/hooks/pre-commit
 
-  run "$BATS_TEST_DIRNAME"/../transcrypt --cipher=aes-256-cbc --password='abc 123' --yes
+  run $TRANSCRYPT --cipher=aes-256-cbc --password='abc 123' --yes
   [ "$status" -eq 0 ]
   [[ "${output}" = *"WARNING:"* ]]
   [[ "${output}" = *"Cannot install Git pre-commit hook script because file already exists: .git/hooks/pre-commit"* ]]
@@ -86,7 +86,7 @@ load "$BATS_TEST_DIRNAME/_test_helper.bash"
 }
 
 @test "pre-commit: de-activate and remove transcrypt's pre-commit hook" {
-  "$BATS_TEST_DIRNAME"/../transcrypt --uninstall --yes
+  $TRANSCRYPT --uninstall --yes
   [ ! -f .git/hooks/pre-commit ]
   [ ! -f .git/hooks/pre-commit-crypt ]
 }
@@ -95,7 +95,7 @@ load "$BATS_TEST_DIRNAME/_test_helper.bash"
   # Customise transcrypt's pre-commit hook
   echo "#" >> .git/hooks/pre-commit
 
-  run "$BATS_TEST_DIRNAME"/../transcrypt --uninstall --yes
+  run $TRANSCRYPT --uninstall --yes
   [ "$status" -eq 0 ]
   [[ "${output}" = *'WARNING: Cannot safely disable Git pre-commit hook .git/hooks/pre-commit please check it yourself'* ]]
   [ -f .git/hooks/pre-commit ]


### PR DESCRIPTION
Addresses #217:

Makes the bats suite isolated and parallel-safe, per the approach
outlined in the issue I just opened:

- Each test builds its git repo in `$BATS_TEST_TMPDIR` instead of the
  shared `tests/` directory; bats owns cleanup, so `nuke_git_repo`,
  `cleanup_all`, and the flag-file guard are removed.
- Tests call the script via absolute `$TRANSCRYPT` rather than
  cwd-relative `../transcrypt`.
- The helper exports `GIT_CONFIG_GLOBAL=/dev/null` and
  `GIT_CONFIG_SYSTEM=/dev/null` (git 2.32+), superseding the
  `merge.conflictStyle` workaround.
- The crypt-dir tests use per-test paths instead of shared `/tmp/crypt`.
- CI installs GNU parallel and runs `bats --jobs 4 tests/`.

No changes to the transcrypt script itself. Serial `bats tests/` still
work, but new runs can specify `bats --jobs 4 tests` or however many make sense.

Local test timing: 95s serial → 26s with `--jobs 16`; 79/79 tests pass.

Note that the macOS users and GH runners needed to `brew install parallel`
